### PR TITLE
Advanced System Scheduler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ std = []
 bumpalo = "3.14.0"
 evenio_macros = { path = "evenio_macros", version = "0.1.1" }
 memoffset = "0.9.0"
+petgraph = { version = "0.6.4", default-features = false, features = [
+    "graphmap",
+] }
 slab = "0.4.9"
 
 [lints]
@@ -32,7 +35,7 @@ license = "MIT"
 repository = "https://github.com/rj00a/evenio"
 
 [workspace.lints.rust]
-elided_lifetimes_in_paths = "allow" # Warned by `future_incompatible`.
+elided_lifetimes_in_paths = "allow"    # Warned by `future_incompatible`.
 future_incompatible = "warn"
 missing_debug_implementations = "warn"
 missing_docs = "warn"

--- a/src/event.rs
+++ b/src/event.rs
@@ -784,11 +784,11 @@ impl<E> EventMut<'_, E> {
     /// #
     /// # let mut world = World::new();
     /// #
-    /// world.add_system(|r: ReceiverMut<E>| {
+    /// let taking = world.add_system(|r: ReceiverMut<E>| {
     ///     EventMut::take(r.event); // Took ownership of event.
     /// });
     ///
-    /// world.add_system(|_: Receiver<E>| panic!("boom"));
+    /// world.add_system((|_: Receiver<E>| panic!("boom")).after(taking));
     ///
     /// world.send(E);
     /// // ^ No panic occurs because the first system took

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod exclusive;
 pub mod fetch;
 mod layout_util;
 pub mod query;
+mod schedule;
 mod slot_map;
 pub mod sparse;
 mod sparse_map;

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -98,5 +98,7 @@ mod tests {
             })
             .after(third),
         );
+
+        world.send(OrderEvent(vec![]));
     }
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,0 +1,38 @@
+//! Graph-based schedule for sorted system ordering
+
+use petgraph::graphmap::DiGraphMap;
+
+use crate::system::SystemInfoPtr;
+
+#[derive(Debug)]
+pub(crate) struct SystemSchedule {
+    /// Directed graph of [`SystemInfoPtr`]s representing system dependencies.
+    graph: DiGraphMap<SystemInfoPtr, ()>,
+    /// List of systems ordered in toposort of the graph.
+    cached_ordering: Vec<SystemInfoPtr>,
+}
+
+impl SystemSchedule {
+    pub(crate) fn new() -> Self {
+        SystemSchedule {
+            graph: DiGraphMap::new(),
+            cached_ordering: Vec::new(),
+        }
+    }
+
+    pub(crate) fn insert(&mut self, system: SystemInfoPtr) -> Result<(), ()> {
+        self.graph.add_node(system);
+
+        self.invalidate()
+    }
+
+    fn invalidate(&mut self) -> Result<(), ()> {
+        match petgraph::algo::toposort(&self.graph, None) {
+            Ok(cache) => {
+                self.cached_ordering = cache;
+                Ok(())
+            }
+            Err(_) => Err(()),
+        }
+    }
+}

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -2,15 +2,17 @@
 
 use petgraph::graphmap::DiGraphMap;
 
-use crate::system::SystemInfoPtr;
+use crate::{prelude::SystemId, system::SystemInfo};
 
 #[derive(Debug)]
 pub(crate) struct SystemSchedule {
-    /// Directed graph of [`SystemInfoPtr`]s representing system dependencies.
-    graph: DiGraphMap<SystemInfoPtr, ()>,
-    /// List of systems ordered in toposort of the graph.
-    cached_ordering: Vec<SystemInfoPtr>,
+    /// Directed graph of [`SystemId`]s representing system dependencies.
+    graph: DiGraphMap<SystemId, ()>,
+    /// List of [`SystemId`]s ordered in toposort of the graph.
+    cached_ordering: Vec<SystemId>,
 }
+
+unsafe impl Sync for SystemSchedule {}
 
 impl SystemSchedule {
     pub(crate) fn new() -> Self {
@@ -20,10 +22,29 @@ impl SystemSchedule {
         }
     }
 
-    pub(crate) fn insert(&mut self, system: SystemInfoPtr) -> Result<(), ()> {
+    pub(crate) fn insert(&mut self, info: &SystemInfo) -> Result<(), ()> {
+        let system = info.id();
         self.graph.add_node(system);
 
+        for before in &info.dependencies().before {
+            self.graph.add_edge(system, *before, ());
+        }
+        for after in &info.dependencies().after {
+            self.graph.add_edge(*after, system, ());
+        }
+
         self.invalidate()
+    }
+
+    pub(crate) fn remove(&mut self, system: SystemId) {
+        self.graph.remove_node(system);
+
+        // cycle errors should panic at insert, shouldn't reach here
+        self.invalidate().unwrap();
+    }
+
+    pub(crate) fn systems(&self) -> &[SystemId] {
+        &self.cached_ordering
     }
 
     fn invalidate(&mut self) -> Result<(), ()> {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -62,10 +62,8 @@ impl SystemSchedule {
 mod tests {
     use evenio_macros::Event;
 
-    use crate::{
-        event::{Receiver, ReceiverMut},
-        prelude::{IntoSystem, World},
-    };
+    use crate::event::{Receiver, ReceiverMut};
+    use crate::prelude::{IntoSystem, World};
 
     #[derive(Debug, PartialEq, Eq)]
     enum MyOrder {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -2,7 +2,8 @@
 
 use petgraph::graphmap::DiGraphMap;
 
-use crate::{prelude::SystemId, system::SystemInfo};
+use crate::prelude::SystemId;
+use crate::system::SystemInfo;
 
 #[derive(Debug)]
 pub(crate) struct SystemSchedule {

--- a/src/system.rs
+++ b/src/system.rs
@@ -44,7 +44,8 @@ use crate::world::{UnsafeWorldCell, World};
 #[derive(Debug)]
 pub struct Systems {
     infos: SlotMap<SystemInfo>,
-    /// Maps untargeted event indices to a schedule that holds the order of execution.
+    /// Maps untargeted event indices to a schedule that holds the order of
+    /// execution.
     untargeted_event_schedulers: Vec<SystemSchedule>,
     by_type_id: BTreeMap<TypeId, SystemInfoPtr>,
 }

--- a/tutorial/ch01_systems_and_events.md
+++ b/tutorial/ch01_systems_and_events.md
@@ -61,20 +61,20 @@ world.add_system(|| {});
 
 When multiple systems listen for the same event, we'll need to consider the order those systems should run when the event is sent.
 
-System order is first determined by the system's [`Priority`]. This is a enum with three states: `Before`, `Normal`, and `After`. `Normal` is the default.
-If systems have the same priority, then we fall back on the order the systems were added to the `World` to decide the order.
+System order is determined by the system's [`Dependencies`]. Those contain information about which systems should run before or after a certain system.
 
-[`Priority`]: crate::system::Priority
+[`Dependencies`]: crate::system::Dependencies
 
 ```rust
 use evenio::prelude::*;
 
 let mut world = World::new();
 
-world.add_system(system_a);
-world.add_system(system_b);
-// Give this system the `Before` priority.
-world.add_system(system_c.before());
+let a = world.add_system(system_a);
+// Run system B after A
+world.add_system(system_b.after(a));
+// Run system C before A
+world.add_system(system_c.before(a));
 
 world.send(MyEvent);
 
@@ -95,12 +95,13 @@ fn system_c(_: Receiver<MyEvent>) {
 ```
 
 Output:
+
 ```txt
 system C
 system A
 system B
 ```
 
-Although `system_c` was added to the world last, it was given `Priority::Before`, so it ran first.
+Although `system_c` was added to the world last, it was forced to run before `system_a`, which should run before `system_b`.
 
 [^1]: Be careful when mixing identifiers from different worlds. An identifier for an item in one `World`, such as an `EntityId`, is meaningless when used in a different `World`.


### PR DESCRIPTION
This PR introduces a graph-based scheduler for events which can be hinted for order with
```rs
let a = world.add_system(system_a);
// Run system B after A
world.add_system(system_b.after(a));
// Run system C before A
world.add_system(system_c.before(a));
```

## Important Change
Systems don't run on insert order anymore!

### Dependencies
- Added `petgraph` with features `graphmap` and without defaults

### Future notes
This still isn't 100% flexible for modular use, because the `SystemId` is still required. We can't change this to the `TypeId` of a system because of the flexibility to add multiple of the same `TypeId`-erased systems.