### PR TITLE
Pass target location through `System::run`.

### DIFF
--- a/evenio_macros/src/system_param.rs
+++ b/evenio_macros/src/system_param.rs
@@ -61,6 +61,7 @@ pub(crate) fn derive_system_param(input: TokenStream) -> Result<TokenStream> {
                             state,
                             info,
                             event_ptr,
+                            target_location,
                             world
                         );
 
@@ -81,6 +82,7 @@ pub(crate) fn derive_system_param(input: TokenStream) -> Result<TokenStream> {
                             state,
                             info,
                             event_ptr,
+                            target_location,
                             world
                         );
 
@@ -130,6 +132,7 @@ pub(crate) fn derive_system_param(input: TokenStream) -> Result<TokenStream> {
                 state: &'__a mut Self::State,
                 info: &'__a ::evenio::system::SystemInfo,
                 event_ptr: ::evenio::event::EventPtr<'__a>,
+                target_location: ::evenio::entity::EntityLocation,
                 world: ::evenio::world::UnsafeWorldCell<'__a>,
             ) -> Self::Item<'__a> {
                 #get_body

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -489,6 +489,7 @@ unsafe impl SystemParam for &'_ Archetypes {
         _state: &'a mut Self::State,
         _info: &'a SystemInfo,
         _event_ptr: EventPtr<'a>,
+        _target_location: EntityLocation,
         world: UnsafeWorldCell<'a>,
     ) -> Self::Item<'a> {
         world.archetypes()
@@ -528,6 +529,11 @@ unsafe impl SparseIndex for ArchetypeIdx {
 /// [`ArchetypeIdx`], this can identify the location of an entity.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct ArchetypeRow(pub u32);
+
+impl ArchetypeRow {
+    /// The archetype row that is always invalid.
+    pub const NULL: Self = Self(u32::MAX);
+}
 
 /// A container for all entities with a particular set of components.
 ///

--- a/src/component.rs
+++ b/src/component.rs
@@ -11,6 +11,7 @@ pub use evenio_macros::Component;
 use crate::archetype::Archetype;
 use crate::assert::UnwrapDebugChecked;
 use crate::drop::DropFn;
+use crate::entity::EntityLocation;
 use crate::event::{Event, EventId, EventPtr};
 use crate::map::{Entry, TypeIdMap};
 use crate::prelude::World;
@@ -179,6 +180,7 @@ unsafe impl SystemParam for &'_ Components {
         _state: &'a mut Self::State,
         _info: &'a SystemInfo,
         _event_ptr: EventPtr<'a>,
+        _target_location: EntityLocation,
         world: UnsafeWorldCell<'a>,
     ) -> Self::Item<'a> {
         world.components()

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -118,6 +118,7 @@ unsafe impl SystemParam for &'_ Entities {
         _state: &'a mut Self::State,
         _info: &'a SystemInfo,
         _event_ptr: EventPtr<'a>,
+        _target_location: EntityLocation,
         world: UnsafeWorldCell<'a>,
     ) -> Self::Item<'a> {
         world.entities()
@@ -135,6 +136,14 @@ pub struct EntityLocation {
     pub archetype: ArchetypeIdx,
     /// The specific row in the archetype where the entity is located.
     pub row: ArchetypeRow,
+}
+
+impl EntityLocation {
+    /// A location which is always invalid.
+    pub(crate) const NULL: Self = Self {
+        archetype: ArchetypeIdx::NULL,
+        row: ArchetypeRow::NULL,
+    };
 }
 
 /// Lightweight identifier for an entity.


### PR DESCRIPTION
Prior to this change, receivers used the event's declared target entity to fetch their query data. This is unsound because the event's target could be changed via mutable receivers. Bad implementations of `Event` were also possible.