### PR TITLE
Fix bug in entity despawning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ ahash = "0.8.7"
 bevy_ecs = { version = "0.13.0", features = ["multi-threaded"] }
 bevy_tasks = "0.13.0"
 divan = "0.1.11"
+rand = "0.8.5"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -509,6 +509,11 @@ impl Archetypes {
 
         arch.entity_ids.swap_remove(loc.row.0 as usize);
 
+        if (loc.row.0 as usize) < arch.entity_ids.len() {
+            let displaced = *unsafe { arch.entity_ids.get_debug_checked(loc.row.0 as usize) };
+            unsafe { entities.get_mut(displaced).unwrap_debug_checked() }.row = loc.row;
+        }
+
         if arch.entity_count() == 0 {
             for mut ptr in arch.refresh_listeners.iter().copied() {
                 unsafe { ptr.as_info_mut().handler_mut().remove_archetype(arch) };

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -961,9 +961,11 @@ mod tests {
         world.send(E1);
     }
 
-    fn _assert_auto_trait_impls<Q>()
+    fn _assert_auto_trait_impls()
     where
-        for<'a> Fetcher<'a, Q>: Send + Sync,
+        for<'a> Fetcher<'a, ()>: Send + Sync,
+        for<'a, 'b> Fetcher<'a, &'b C1>: Send + Sync,
+        for<'a, 'b, 'c> Fetcher<'a, (&'b C1, &'c mut C2)>: Send + Sync,
     {
     }
 }


### PR DESCRIPTION
When entities were swap removed from archetypes, the displaced entity's `EntityLocation` was not updated properly.

Closes #31 