### PR TITLE
fix: incompatible component access issue for gt 2 queries

### DIFF
--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -675,7 +675,6 @@ impl Archetype {
     fn register_handler(&mut self, info: &mut HandlerInfo) {
         if info
             .component_access()
-            .expr
             .eval(|idx| self.column_of(idx).is_some())
         {
             if self.entity_count() > 0 {

--- a/src/event.rs
+++ b/src/event.rs
@@ -904,9 +904,7 @@ unsafe impl<E: Event, Q: Query + 'static> HandlerParam for Receiver<'_, E, Q> {
 
         config.targeted_event_expr = expr.expr.clone();
 
-        if let Ok(new_component_access) = expr.or(&config.component_access) {
-            config.component_access = new_component_access;
-        } else {
+        if config.try_add_component_access(expr).is_err() {
             return Err(InitError(
                 format!(
                     "query `{}` has incompatible component access with previous queries in this \
@@ -1022,9 +1020,7 @@ unsafe impl<E: Event, Q: Query + 'static> HandlerParam for ReceiverMut<'_, E, Q>
 
         config.targeted_event_expr = expr.expr.clone();
 
-        if let Ok(new_component_access) = expr.or(&config.component_access) {
-            config.component_access = new_component_access;
-        } else {
+        if config.try_add_component_access(expr).is_err() {
             return Err(InitError(
                 format!(
                     "query `{}` has incompatible component access with previous queries in this \

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -34,18 +34,15 @@ impl<Q: Query> FetcherState<Q> {
 
         let res = FetcherState::new(state);
 
-        match expr.or(&config.component_access) {
-            Ok(new_component_access) => config.component_access = new_component_access,
-            Err(_) => {
-                return Err(InitError(
-                    format!(
-                        "query `{}` has incompatible component access with previous queries in \
-                         this handler",
-                        any::type_name::<Q>()
-                    )
-                    .into(),
-                ))
-            }
+        if config.try_add_component_access(expr).is_err() {
+            return Err(InitError(
+                format!(
+                    "query `{}` has incompatible component access with previous queries in this \
+                     handler",
+                    any::type_name::<Q>()
+                )
+                .into(),
+            ));
         }
 
         Ok(res)


### PR DESCRIPTION
This commit resolves an issue where queries with different component access expressions were incorrectly identified as incompatible when used together in an event handler. The problem was rooted in the logic that combined the component access expressions: it failed to account for the scenario where multiple queries in a handler could be compatible individually but not when combined.

# TODO

- [ ] add more tests
- [ ] clean up docs
- [ ] possibly better naming to clarify whether `BoolExpr` or `ComponentAccessExpr`.