### PR TITLE
Add more unit tests for queries and fix regression.

### DIFF
--- a/src/access.rs
+++ b/src/access.rs
@@ -280,9 +280,15 @@ impl ComponentAccess {
     where
         F: FnMut(ComponentIdx) -> bool,
     {
-        self.cases
-            .iter()
-            .any(|case| case.iter().all(|(idx, _)| f(*idx)))
+        self.cases.iter().any(|case| {
+            case.iter().all(|&(idx, access)| match access {
+                CaseAccess::With => f(idx),
+                CaseAccess::Read => f(idx),
+                CaseAccess::ReadWrite => f(idx),
+                CaseAccess::Not => !f(idx),
+                CaseAccess::Conflict => f(idx),
+            })
+        })
     }
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -415,7 +415,7 @@ where
         let (ca_rhs, state_rhs) = R::init(world, config)?;
 
         Ok((
-            dbg!(ca_lhs.and(&ca_rhs.not()).or(&ca_rhs.and(&ca_lhs.not()))),
+            ca_lhs.and(&ca_rhs.not()).or(&ca_rhs.and(&ca_lhs.not())),
             (state_lhs, state_rhs),
         ))
     }


### PR DESCRIPTION
`Not<Q>` queries weren't being handled correctly in `matches_archetype`. There are now unit tests to cover this.

Should fix the issue mentioned in https://github.com/rj00a/evenio/pull/35#issuecomment-2040239497