### PR TITLE
Implement non-`'static` events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Added `Deref` and `DerefMut` impls for `Single`, `TrySingle`, `Has<Q>`.
+- Allow sending events with borrowed data in `World::send`.
+- Removed `'static` bound from `Event`. `Event` is now an `unsafe` trait to implement.
+- Removed `World::send_many`.
 
 ## 0.5.0 - 2024-04-07
 

--- a/evenio_macros/src/event.rs
+++ b/evenio_macros/src/event.rs
@@ -1,8 +1,8 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
-use syn::{parse2, parse_quote, Data, DeriveInput, LitInt, Result};
+use syn::{parse2, parse_quote, Data, DeriveInput, LitInt, Result, Type};
 
-use crate::util::parse_attr_immutable;
+use crate::util::{parse_attr_immutable, replace_lifetime};
 
 pub(crate) fn derive_event(input: TokenStream) -> Result<TokenStream> {
     let mut input = parse2::<DeriveInput>(input)?;
@@ -89,9 +89,18 @@ pub(crate) fn derive_event(input: TokenStream) -> Result<TokenStream> {
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
+    let mut this: Type = parse_quote!(#name #ty_generics);
+
+    let new_lifetime_ident = parse_quote!(__a);
+    for life in input.generics.lifetimes() {
+        replace_lifetime(&mut this, &life.lifetime.ident, &new_lifetime_ident);
+    }
+
     Ok(quote! {
         #[automatically_derived]
-        impl #impl_generics ::evenio::event::Event for #name #ty_generics #where_clause {
+        unsafe impl #impl_generics ::evenio::event::Event for #name #ty_generics #where_clause {
+            type This<'__a> = #this;
+
             const IS_TARGETED: bool = #is_targeted;
             const IS_IMMUTABLE: bool = #is_immutable;
 

--- a/evenio_macros/src/event.rs
+++ b/evenio_macros/src/event.rs
@@ -11,7 +11,7 @@ pub(crate) fn derive_event(input: TokenStream) -> Result<TokenStream> {
         .generics
         .make_where_clause()
         .predicates
-        .push(parse_quote!(Self: Send + Sync + 'static));
+        .push(parse_quote!(Self: Send + Sync));
 
     let mut target_field = None;
 

--- a/evenio_macros/src/handler_param.rs
+++ b/evenio_macros/src/handler_param.rs
@@ -39,7 +39,7 @@ pub(crate) fn derive_handler_param(input: TokenStream) -> Result<TokenStream> {
                 }
 
                 where_clause.predicates.push(
-                    parse_quote!(#ty: for<'__a> ::evenio::handler::HandlerParam<Item<'__a> = #replaced_ty>),
+                    parse_quote!(#ty: for<'__a> ::evenio::handler::HandlerParam<This<'__a> = #replaced_ty>),
                 );
             }
 
@@ -108,9 +108,9 @@ pub(crate) fn derive_handler_param(input: TokenStream) -> Result<TokenStream> {
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    let mut item: Type = parse_quote!(#name #ty_generics);
+    let mut this: Type = parse_quote!(#name #ty_generics);
     for life in &lifetimes {
-        replace_lifetime(&mut item, &life.lifetime.ident, &parse_quote!(__a));
+        replace_lifetime(&mut this, &life.lifetime.ident, &parse_quote!(__a));
     }
 
     Ok(quote! {
@@ -118,7 +118,7 @@ pub(crate) fn derive_handler_param(input: TokenStream) -> Result<TokenStream> {
         unsafe impl #impl_generics ::evenio::handler::HandlerParam for #name #ty_generics #where_clause {
             type State = <#tuple_ty as ::evenio::handler::HandlerParam>::State;
 
-            type Item<'__a> = #item;
+            type This<'__a> = #this;
 
             fn init(
                 world: &mut ::evenio::world::World,
@@ -134,7 +134,7 @@ pub(crate) fn derive_handler_param(input: TokenStream) -> Result<TokenStream> {
                 event_ptr: ::evenio::event::EventPtr<'__a>,
                 target_location: ::evenio::entity::EntityLocation,
                 world: ::evenio::world::UnsafeWorldCell<'__a>,
-            ) -> Self::Item<'__a> {
+            ) -> Self::This<'__a> {
                 #get_body
             }
 

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -541,7 +541,7 @@ impl Index<ArchetypeIdx> for Archetypes {
 unsafe impl HandlerParam for &'_ Archetypes {
     type State = ();
 
-    type Item<'a> = &'a Archetypes;
+    type This<'a> = &'a Archetypes;
 
     fn init(_world: &mut World, _config: &mut HandlerConfig) -> Result<Self::State, InitError> {
         Ok(())
@@ -553,7 +553,7 @@ unsafe impl HandlerParam for &'_ Archetypes {
         _event_ptr: EventPtr<'a>,
         _target_location: EntityLocation,
         world: UnsafeWorldCell<'a>,
-    ) -> Self::Item<'a> {
+    ) -> Self::This<'a> {
         world.archetypes()
     }
 

--- a/src/component.rs
+++ b/src/component.rs
@@ -173,7 +173,7 @@ impl Index<TypeId> for Components {
 unsafe impl HandlerParam for &'_ Components {
     type State = ();
 
-    type Item<'a> = &'a Components;
+    type This<'a> = &'a Components;
 
     fn init(_world: &mut World, _config: &mut HandlerConfig) -> Result<Self::State, InitError> {
         Ok(())
@@ -185,7 +185,7 @@ unsafe impl HandlerParam for &'_ Components {
         _event_ptr: EventPtr<'a>,
         _target_location: EntityLocation,
         world: UnsafeWorldCell<'a>,
-    ) -> Self::Item<'a> {
+    ) -> Self::This<'a> {
         world.components()
     }
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -108,7 +108,7 @@ impl Index<EntityIdx> for Entities {
 unsafe impl HandlerParam for &'_ Entities {
     type State = ();
 
-    type Item<'a> = &'a Entities;
+    type This<'a> = &'a Entities;
 
     fn init(_world: &mut World, _config: &mut HandlerConfig) -> Result<Self::State, InitError> {
         Ok(())
@@ -120,7 +120,7 @@ unsafe impl HandlerParam for &'_ Entities {
         _event_ptr: EventPtr<'a>,
         _target_location: EntityLocation,
         world: UnsafeWorldCell<'a>,
-    ) -> Self::Item<'a> {
+    ) -> Self::This<'a> {
         world.entities()
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -288,21 +288,21 @@ unsafe impl HandlerParam for &'_ Events {
 ///
 /// # Safety
 ///
-/// This trait is `unsafe` to implement because unsafe code relies on the
-/// implementations of [`This`] and [`target`] being correct to avoid undefined
-/// behavior. Note that implementations produced by the derive macro are always
-/// safe.
+/// This trait is `unsafe` to implement because unsafe code relies on correct
+/// implementations of [`This`] and [`target`] to avoid undefined behavior. Note
+/// that implementations produced by the derive macro are always safe.
 ///
 /// [`This`]: Self::This
 /// [`target`]: Self::target
 pub unsafe trait Event: Send + Sync {
-    /// The type of `Self` with the lifetime of `'a`.
+    /// The type of `Self`, but with lifetimes modified to outlive `'a`.
     ///
     /// # Safety
     ///
     /// This type _must_ correspond to the type of `Self`. In particular, it
-    /// must be safe to transmute between `Self` and `This<'a>`. Additionally,
-    /// the [`TypeId`] of `Self` must match that of `This<'static>`.
+    /// must be safe to transmute between `Self` and `This<'a>` (assuming `'a`
+    /// is correct). Additionally, the [`TypeId`] of `Self` must match that
+    /// of `This<'static>`.
     type This<'a>: 'a;
 
     /// If this event is considered "targeted" or "untargeted".

--- a/src/event.rs
+++ b/src/event.rs
@@ -1606,35 +1606,6 @@ mod tests {
         );
     }
 
-    /*
-    #[test]
-    fn event_order_send_many() {
-        let mut world = World::new();
-
-        #[derive(Event)]
-        struct E(i32);
-
-        #[derive(Component)]
-        struct Result(Vec<i32>);
-
-        world.add_handler(|r: Receiver<E>, res: Single<&mut Result>| {
-            res.0 .0.push(r.event.0);
-        });
-
-        let e = world.spawn();
-        world.insert(e, Result(vec![]));
-
-        world.send_many(|mut s| {
-            s.send(E(1));
-            s.send(E(2));
-            s.send(E(3));
-        });
-
-        let Result(values) = world.get_mut::<Result>(e).unwrap();
-        assert_eq!(values, &[1, 2, 3]);
-    }
-    */
-
     #[test]
     fn change_event_target() {
         let mut world = World::new();

--- a/src/event.rs
+++ b/src/event.rs
@@ -1689,4 +1689,27 @@ mod tests {
 
         assert_eq!(world.entities().len(), 0);
     }
+
+    #[test]
+    fn send_borrowed() {
+        let mut buf = [1, 2, 3];
+
+        #[derive(Event, Debug)]
+        struct A<'a>(&'a mut [i32]);
+
+        impl Drop for A<'_> {
+            fn drop(&mut self) {
+                for item in self.0.iter_mut() {
+                    *item *= 2;
+                    println!("{item}");
+                }
+            }
+        }
+
+        let mut world = World::new();
+
+        world.add_handler(|r: Receiver<A>| println!("{r:?}"));
+
+        world.send(A(&mut buf));
+    }
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -369,7 +369,7 @@ where
 {
     type State = FetcherState<Q>;
 
-    type Item<'a> = Fetcher<'a, Q>;
+    type This<'a> = Fetcher<'a, Q>;
 
     fn init(world: &mut World, config: &mut HandlerConfig) -> Result<Self::State, InitError> {
         FetcherState::init(world, config)
@@ -381,7 +381,7 @@ where
         _event_ptr: EventPtr<'a>,
         _target_location: EntityLocation,
         world: UnsafeWorldCell<'a>,
-    ) -> Self::Item<'a> {
+    ) -> Self::This<'a> {
         Fetcher { state, world }
     }
 
@@ -428,7 +428,7 @@ pub struct Single<'a, Q: Query>(pub Q::Item<'a>);
 unsafe impl<Q: Query + 'static> HandlerParam for Single<'_, Q> {
     type State = FetcherState<Q>;
 
-    type Item<'a> = Single<'a, Q>;
+    type This<'a> = Single<'a, Q>;
 
     fn init(world: &mut World, config: &mut HandlerConfig) -> Result<Self::State, InitError> {
         FetcherState::init(world, config)
@@ -441,7 +441,7 @@ unsafe impl<Q: Query + 'static> HandlerParam for Single<'_, Q> {
         event_ptr: EventPtr<'a>,
         target_location: EntityLocation,
         world: UnsafeWorldCell<'a>,
-    ) -> Self::Item<'a> {
+    ) -> Self::This<'a> {
         match TrySingle::get(state, info, event_ptr, target_location, world) {
             TrySingle(Ok(item)) => Single(item),
             TrySingle(Err(e)) => {
@@ -486,7 +486,7 @@ pub struct TrySingle<'a, Q: Query>(pub Result<Q::Item<'a>, SingleError>);
 unsafe impl<Q: Query + 'static> HandlerParam for TrySingle<'_, Q> {
     type State = FetcherState<Q>;
 
-    type Item<'a> = TrySingle<'a, Q>;
+    type This<'a> = TrySingle<'a, Q>;
 
     fn init(world: &mut World, config: &mut HandlerConfig) -> Result<Self::State, InitError> {
         FetcherState::init(world, config)
@@ -498,7 +498,7 @@ unsafe impl<Q: Query + 'static> HandlerParam for TrySingle<'_, Q> {
         _event_ptr: EventPtr<'a>,
         _target_location: EntityLocation,
         world: UnsafeWorldCell<'a>,
-    ) -> Self::Item<'a> {
+    ) -> Self::This<'a> {
         let mut it = state.iter_mut(world.archetypes());
 
         let Some(item) = it.next() else {

--- a/src/world.rs
+++ b/src/world.rs
@@ -98,47 +98,6 @@ impl World {
         self.flush_event_queue();
     }
 
-    /*
-    /// Enqueue an arbitrary number of events and send them all at once.
-    ///
-    /// The closure `f` is passed a [`Sender`] used to add events to a queue.
-    /// Once the closure returns, all enqueued events are broadcasted as
-    /// described by [`send`].
-    ///
-    /// [`send`]: World::send
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use evenio::prelude::*;
-    /// #
-    /// # #[derive(Event)]
-    /// # struct A;
-    /// #
-    /// # #[derive(Event)]
-    /// # struct B;
-    /// #
-    /// # let mut world = World::new();
-    /// #
-    /// world.send_many(|mut sender| {
-    ///     sender.send(A);
-    ///     sender.send(B);
-    /// });
-    /// ```
-    pub fn send_many<F, R>(&mut self, f: F) -> R
-    where
-        F: FnOnce(Sender) -> R,
-    {
-        let event_count = self.event_queue.len();
-        let res = f(Sender { world: self });
-        unsafe { self.event_queue.reverse_from(event_count) };
-
-        self.flush_event_queue();
-
-        res
-    }
-    */
-
     /// Creates a new entity, returns its [`EntityId`], and sends the [`Spawn`]
     /// event to signal its creation.
     ///
@@ -1088,52 +1047,6 @@ impl Default for World {
         Self::new()
     }
 }
-
-/*
-/// Used for queueing events. Passed to the closure given in [`send_many`].
-///
-/// [`send_many`]: World::send_many
-#[derive(Debug)]
-pub struct Sender<'a> {
-    world: &'a mut World,
-}
-
-impl<'a> Sender<'a> {
-    /// Enqueue an event.
-    pub fn send<E: Event + 'a>(&mut self, event: E) {
-        let idx = self.world.add_event::<E>().index().as_u32();
-        unsafe { self.world.event_queue.push_front(event, idx) };
-    }
-
-    /// Enqueue the spawning of an entity and [`Spawn`] event. Returns the
-    /// [`EntityId`] of the entity that will be spawned.
-    pub fn spawn(&mut self) -> EntityId {
-        let id = self.world.reserved_entities.reserve(&self.world.entities);
-        unsafe {
-            self.world
-                .event_queue
-                .push_front(SpawnQueued, EventId::SPAWN_QUEUED.index().as_u32())
-        }
-        self.send(Spawn(id));
-        id
-    }
-
-    /// Enqueue an [`Insert`] event.
-    pub fn insert<C: Component>(&mut self, entity: EntityId, component: C) {
-        self.send(Insert::new(entity, component))
-    }
-
-    /// Enqueue a [`Remove`] event.
-    pub fn remove<C: Component>(&mut self, entity: EntityId) {
-        self.send(Remove::<C>::new(entity))
-    }
-
-    /// Enqueue a [`Despawn`] event.
-    pub fn despawn(&mut self, entity: EntityId) {
-        self.send(Despawn(entity))
-    }
-}
-*/
 
 /// Reference to a [`World`] where all methods take `&self` and aliasing rules
 /// are not checked. It is the caller's responsibility to ensure that


### PR DESCRIPTION
Closes #41

This PR removes the `'static` bound from the `Event` trait. `World::send` can now send events containing borrowed data from outside the `World`. However, `Sender::send` still requires `'static`.

## Additional Changes
- Removed `World::send_many`. I wasn't sure how to make the lifetimes correct here, and the method doesn't have any real benefits until #4 or #5 is implemented. It could be added again if needed.
- Added `Event::This<'a>`. Because `Event` is no longer `'static`, we need this associated type in order to get a canonical `TypeId`. It also resolves a tricky lifetime issue in the implementation of `HandlerParam` for `Receiver`/`ReceiverMut`. This does mean that `Event` is now an `unsafe` trait, but it can continue to be implemented safely with the derive macro.