### PR TITLE
Improve `iter` benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ slab = "0.4.9"
 
 [dev-dependencies]
 ahash = "0.8.7"
-bevy_ecs = { version = "0.13.0", features = ["multi-threaded"] }
-bevy_tasks = "0.13.0"
+bevy_ecs = { version = "0.13.2", features = ["multi-threaded"] }
+bevy_tasks = "0.13.2"
 divan = "0.1.11"
 rand = "0.8.5"
 

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -178,8 +178,8 @@ fn iter_mandelbrot_bevy<const PARALLEL: bool>(bencher: Bencher, iters: usize) {
 fn mandelbrot(x: u16, y: u16, iters: usize) -> bool {
     let scale = 2.;
 
-    let cr = x as f64 / (IMAGE_SIZE - 1) as f64 * scale - scale / 2.;
-    let ci = y as f64 / (IMAGE_SIZE - 1) as f64 * scale - scale / 2.;
+    let cr = f64::from(x) / f64::from(IMAGE_SIZE - 1) * scale - scale / 2.;
+    let ci = f64::from(y) / f64::from(IMAGE_SIZE - 1) * scale - scale / 2.;
 
     let mut zr = cr;
     let mut zi = ci;
@@ -197,7 +197,7 @@ fn mandelbrot(x: u16, y: u16, iters: usize) -> bool {
 
 #[allow(unused)]
 fn make_mandel_pgm(iters: usize) -> std::io::Result<()> {
-    let mut pgm = format!("P2 {0} {0} 1\n", IMAGE_SIZE);
+    let mut pgm = format!("P2 {IMAGE_SIZE} {IMAGE_SIZE} 1\n");
 
     for y in 0..IMAGE_SIZE {
         for x in 0..IMAGE_SIZE {

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -7,7 +7,7 @@ fn main() {
 }
 
 const DATA: f64 = 123456789.0;
-const ARGS: [usize; 7] = [1, 10, 100, 1_000, 10_000, 100_000, 1_000_000];
+const LENS: [usize; 7] = [1, 10, 100, 1_000, 10_000, 100_000, 1_000_000];
 
 #[derive(evenio::component::Component, bevy_ecs::component::Component)]
 struct C1(f64);
@@ -21,72 +21,11 @@ struct C3(#[allow(dead_code)] f64);
 #[derive(evenio::event::Event)]
 struct E;
 
-#[divan::bench(args = ARGS)]
-fn iter_evenio(bencher: Bencher, len: usize) {
-    use evenio::prelude::*;
-
-    let mut world = World::new();
-
-    for i in 0..len {
-        let e = world.spawn();
-
-        world.insert(e, C1(42.0));
-
-        if i % 2 == 0 {
-            world.insert(e, C2(42.0));
-        }
-
-        if i % 3 == 0 {
-            world.insert(e, C3(42.0));
-        }
-    }
-
-    world.add_handler(move |_: Receiver<E>, f: Fetcher<&mut C1>| {
-        for c in f {
-            c.0 = c.0.sqrt();
-        }
-    });
-
-    bencher.bench_local(|| world.send(E));
-}
-
-#[divan::bench(args = ARGS)]
-fn iter_bevy(bencher: Bencher, len: usize) {
-    use bevy_ecs::prelude::*;
-
-    let mut world = World::new();
-
-    for i in 0..len {
-        let mut e = world.spawn(C1(DATA));
-
-        if i % 2 == 0 {
-            e.insert(C2(DATA));
-        }
-
-        if i % 3 == 0 {
-            e.insert(C3(DATA));
-        }
-    }
-
-    let mut state = world.query::<&mut C1>();
-
-    bencher.bench_local(|| {
-        for mut c in state.iter_mut(&mut world) {
-            c.bypass_change_detection().0 = c.0.sqrt();
-        }
-    });
-}
-
-// TODO: iteration with high fragmentation.
-
 #[cfg(feature = "rayon")]
-#[divan::bench(args = ARGS)]
-fn par_iter_evenio(bencher: Bencher, len: usize) {
+#[divan::bench(args = LENS, consts = [false, true])]
+fn iter_simple_evenio<const PARALLEL: bool>(bencher: Bencher, len: usize) {
     use evenio::prelude::*;
-    use rayon::prelude::*;
-
-    #[derive(Event)]
-    struct E;
+    use evenio::rayon::prelude::*;
 
     let mut world = World::new();
 
@@ -105,20 +44,28 @@ fn par_iter_evenio(bencher: Bencher, len: usize) {
     }
 
     world.add_handler(move |_: Receiver<E>, f: Fetcher<&mut C1>| {
-        f.into_par_iter().for_each(|c| {
-            c.0 = c.0.sqrt();
-        });
+        if PARALLEL {
+            f.into_par_iter().for_each(|c| {
+                c.0 = c.0.sqrt();
+            });
+        } else {
+            f.into_iter().for_each(|c| {
+                c.0 = c.0.sqrt();
+            });
+        }
     });
 
     bencher.bench_local(|| world.send(E));
 }
 
-#[divan::bench(args = ARGS)]
-fn par_iter_bevy(bencher: Bencher, len: usize) {
+#[divan::bench(args = LENS, consts = [false, true])]
+fn iter_simple_bevy<const PARALLEL: bool>(bencher: Bencher, len: usize) {
     use bevy_ecs::prelude::*;
     use bevy_tasks::{ComputeTaskPool, TaskPool};
 
-    ComputeTaskPool::get_or_init(TaskPool::new);
+    if PARALLEL {
+        ComputeTaskPool::get_or_init(TaskPool::new);
+    }
 
     let mut world = World::new();
 
@@ -137,10 +84,127 @@ fn par_iter_bevy(bencher: Bencher, len: usize) {
     let mut state = world.query::<&mut C1>();
 
     bencher.bench_local(|| {
-        state.par_iter_mut(&mut world).for_each(|mut c| {
-            c.bypass_change_detection().0 = c.0.sqrt();
-        });
+        if PARALLEL {
+            state.par_iter_mut(&mut world).for_each(|mut c| {
+                c.bypass_change_detection().0 = c.0.sqrt();
+            });
+        } else {
+            state.iter_mut(&mut world).for_each(|mut c| {
+                c.bypass_change_detection().0 = c.0.sqrt();
+            });
+        }
     });
 }
 
-// TODO: parallel iteration with varying amounts of work per iteration.
+const ITERS_PER_PIXEL: [usize; 11] = [1, 2, 3, 8, 16, 32, 64, 128, 256, 512, 1024];
+const IMAGE_SIZE: u16 = 100;
+
+#[derive(evenio::component::Component, bevy_ecs::component::Component)]
+struct Pixel(u16, u16);
+
+#[derive(evenio::component::Component, bevy_ecs::component::Component)]
+struct Output(bool);
+
+#[cfg(feature = "rayon")]
+#[divan::bench(args = ITERS_PER_PIXEL, consts = [true])]
+fn iter_mandelbrot_evenio<const PARALLEL: bool>(bencher: Bencher, iters: usize) {
+    use evenio::prelude::*;
+    use evenio::rayon::prelude::*;
+
+    let mut world = World::new();
+
+    for y in 0..IMAGE_SIZE {
+        for x in 0..IMAGE_SIZE {
+            let e = world.spawn();
+            world.insert(e, Pixel(x, y));
+            world.insert(e, Output(false));
+        }
+    }
+
+    world.add_handler(move |_: Receiver<E>, f: Fetcher<(&Pixel, &mut Output)>| {
+        if PARALLEL {
+            f.into_par_iter().for_each(|(&Pixel(x, y), out)| {
+                out.0 = mandelbrot(x, y, iters);
+            });
+        } else {
+            f.into_iter().for_each(|(&Pixel(x, y), out)| {
+                out.0 = mandelbrot(x, y, iters);
+            });
+        }
+    });
+
+    bencher.bench_local(|| {
+        world.send(E);
+    });
+}
+
+#[divan::bench(args = ITERS_PER_PIXEL, consts = [true])]
+fn iter_mandelbrot_bevy<const PARALLEL: bool>(bencher: Bencher, iters: usize) {
+    use bevy_ecs::prelude::*;
+    use bevy_tasks::{ComputeTaskPool, TaskPool};
+
+    if PARALLEL {
+        ComputeTaskPool::get_or_init(TaskPool::new);
+    }
+
+    let mut world = World::new();
+
+    for y in 0..IMAGE_SIZE {
+        for x in 0..IMAGE_SIZE {
+            world.spawn((Pixel(x, y), Output(false)));
+        }
+    }
+
+    let mut state = world.query::<(&Pixel, &mut Output)>();
+
+    bencher.bench_local(|| {
+        if PARALLEL {
+            state
+                .par_iter_mut(&mut world)
+                .for_each(move |(&Pixel(x, y), mut out)| {
+                    out.bypass_change_detection().0 = mandelbrot(x, y, iters);
+                });
+        } else {
+            state
+                .iter_mut(&mut world)
+                .for_each(|(&Pixel(x, y), mut out)| {
+                    out.bypass_change_detection().0 = mandelbrot(x, y, iters);
+                });
+        }
+    });
+}
+
+#[inline]
+fn mandelbrot(x: u16, y: u16, iters: usize) -> bool {
+    let scale = 2.;
+
+    let cr = x as f64 / (IMAGE_SIZE - 1) as f64 * scale - scale / 2.;
+    let ci = y as f64 / (IMAGE_SIZE - 1) as f64 * scale - scale / 2.;
+
+    let mut zr = cr;
+    let mut zi = ci;
+
+    for _ in 0..iters {
+        if zr * zr + zi * zi >= 4. {
+            return false;
+        }
+
+        (zr, zi) = (zr * zr - zi * zi + cr, 2. * zr * zi + ci);
+    }
+
+    true
+}
+
+#[allow(unused)]
+fn make_mandel_pgm(iters: usize) -> std::io::Result<()> {
+    let mut pgm = format!("P2 {0} {0} 1\n", IMAGE_SIZE);
+
+    for y in 0..IMAGE_SIZE {
+        for x in 0..IMAGE_SIZE {
+            pgm += if mandelbrot(x, y, iters) { " 1" } else { " 0" };
+        }
+        pgm += "\n";
+    }
+
+    std::fs::write("mandel.pgm", pgm)
+}


### PR DESCRIPTION
This adds a Mandelbrot set rendering test.

```
Timer precision: 14 ns
iter                       fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ iter_mandelbrot_bevy                  │               │               │               │         │
│  ╰─ true                               │               │               │               │         │
│     ├─ 1                 14.56 µs      │ 44.36 µs      │ 17.92 µs      │ 18.94 µs      │ 100     │ 100
│     ├─ 2                 20.22 µs      │ 171 µs        │ 25.63 µs      │ 30.71 µs      │ 100     │ 100
│     ├─ 3                 29.03 µs      │ 88.89 µs      │ 32.37 µs      │ 34.3 µs       │ 100     │ 100
│     ├─ 8                 49.01 µs      │ 245.1 µs      │ 59.46 µs      │ 72.94 µs      │ 100     │ 100
│     ├─ 16                83.35 µs      │ 319.6 µs      │ 105.3 µs      │ 122.2 µs      │ 100     │ 100
│     ├─ 32                150.5 µs      │ 395.7 µs      │ 185.9 µs      │ 204.4 µs      │ 100     │ 100
│     ├─ 64                290.9 µs      │ 1.102 ms      │ 362.4 µs      │ 395.1 µs      │ 100     │ 100
│     ├─ 128               606.5 µs      │ 1.209 ms      │ 667.1 µs      │ 724 µs        │ 100     │ 100
│     ├─ 256               1.134 ms      │ 1.837 ms      │ 1.185 ms      │ 1.216 ms      │ 100     │ 100
│     ├─ 512               2.202 ms      │ 2.835 ms      │ 2.263 ms      │ 2.269 ms      │ 100     │ 100
│     ╰─ 1024              4.26 ms       │ 4.531 ms      │ 4.336 ms      │ 4.337 ms      │ 100     │ 100
├─ iter_mandelbrot_evenio                │               │               │               │         │
│  ╰─ true                               │               │               │               │         │
│     ├─ 1                 17.93 µs      │ 274.2 µs      │ 21.13 µs      │ 25.74 µs      │ 100     │ 100
│     ├─ 2                 27 µs         │ 518.5 µs      │ 48.14 µs      │ 58.68 µs      │ 100     │ 100
│     ├─ 3                 38.12 µs      │ 720.1 µs      │ 73.36 µs      │ 92.16 µs      │ 100     │ 100
│     ├─ 8                 54.64 µs      │ 688.9 µs      │ 105 µs        │ 116.2 µs      │ 100     │ 100
│     ├─ 16                82.64 µs      │ 1.335 ms      │ 146.6 µs      │ 173.2 µs      │ 100     │ 100
│     ├─ 32                154.3 µs      │ 1.646 ms      │ 252.9 µs      │ 267 µs        │ 100     │ 100
│     ├─ 64                250.1 µs      │ 1.742 ms      │ 403.4 µs      │ 453.4 µs      │ 100     │ 100
│     ├─ 128               400.4 µs      │ 1.552 ms      │ 517 µs        │ 550.8 µs      │ 100     │ 100
│     ├─ 256               625.1 µs      │ 1.488 ms      │ 849.3 µs      │ 883.9 µs      │ 100     │ 100
│     ├─ 512               1.196 ms      │ 2.349 ms      │ 1.25 ms       │ 1.333 ms      │ 100     │ 100
│     ╰─ 1024              2.334 ms      │ 3.603 ms      │ 2.412 ms      │ 2.484 ms      │ 100     │ 100
```

evenio's parallel iterators pull ahead once the workload becomes sufficiently uneven or large (by cranking up the image resolution or iters per pixel).