### PR TITLE
Fix auto trait impls

### DIFF
--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -6,6 +6,7 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::cmp::Ordering;
 use core::ops::Index;
+use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr::NonNull;
 use core::{fmt, mem, ptr, slice};
 
@@ -806,6 +807,10 @@ impl Drop for Archetype {
 unsafe impl Send for Archetype {}
 unsafe impl Sync for Archetype {}
 
+// Similar logic as above follows for these impls.
+impl UnwindSafe for Archetype {}
+impl RefUnwindSafe for Archetype {}
+
 impl fmt::Debug for Archetype {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Archetype")
@@ -840,6 +845,10 @@ impl Column {
 // required to actually read or write the column data.
 unsafe impl Send for Column {}
 unsafe impl Sync for Column {}
+
+// Similar logic as above follows for these impls.
+impl UnwindSafe for Column {}
+impl RefUnwindSafe for Column {}
 
 #[cfg(test)]
 mod tests {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -3,6 +3,7 @@
 use core::iter::FusedIterator;
 use core::mem::{self, MaybeUninit};
 use core::ops::{Deref, DerefMut};
+use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr::NonNull;
 use core::{any, fmt};
 
@@ -188,6 +189,20 @@ impl<Q: Query> FetcherState<Q> {
     pub(crate) fn remove_archetype(&mut self, arch: &Archetype) {
         self.map.remove(arch.index());
     }
+}
+
+unsafe impl<'a, Q> Send for Fetcher<'a, Q>
+where
+    Q: Query,
+    Q::Item<'a>: Send,
+{
+}
+
+unsafe impl<'a, Q> Sync for Fetcher<'a, Q>
+where
+    Q: Query,
+    Q::Item<'a>: Sync,
+{
 }
 
 impl<Q: Query> fmt::Debug for FetcherState<Q> {
@@ -679,6 +694,20 @@ unsafe impl<'a, Q> Sync for Iter<'a, Q>
 where
     Q: Query,
     Q::Item<'a>: Sync,
+{
+}
+
+impl<'a, Q> UnwindSafe for Iter<'a, Q>
+where
+    Q: Query,
+    Q::Item<'a>: UnwindSafe,
+{
+}
+
+impl<'a, Q> RefUnwindSafe for Iter<'a, Q>
+where
+    Q: Query,
+    Q::Item<'a>: RefUnwindSafe,
 {
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -9,7 +9,6 @@ use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut, Index};
-use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr::NonNull;
 use core::{any, fmt};
 
@@ -320,9 +319,6 @@ pub(crate) struct HandlerInfoInner<H: ?Sized = dyn Handler> {
     // aliasing.
     pub(crate) handler: H,
 }
-
-impl<H: ?Sized> UnwindSafe for HandlerInfoInner<H> {}
-impl<H: ?Sized> RefUnwindSafe for HandlerInfoInner<H> {}
 
 impl HandlerInfo {
     pub(crate) fn new<H: Handler>(inner: HandlerInfoInner<H>) -> Self {


### PR DESCRIPTION
Fixes some slightly incorrect auto trait implementations. In particular, this adds conditional `Send` and `Sync` impls for `Fetcher` following #48.