### PR TITLE
Remove `DebugChecked` extension traits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
-          toolchain: "1.78.0" # MSRV
+          toolchain: "nightly"
           components: "rustfmt"
 
       - name: cargo fmt

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -1,10 +1,7 @@
 //! Utilities for runtime and compile-time assertions.
 
 use core::marker::PhantomData;
-use core::slice::SliceIndex;
-use core::{fmt, mem};
-
-use slab::Slab;
+use core::mem;
 
 use crate::component::Component;
 use crate::event::Event;
@@ -14,161 +11,11 @@ const _: () = assert!(
     "unsupported target"
 );
 
-/// Extension trait for checked array indexing with checks removed in release
-/// mode.
-pub(crate) trait GetDebugChecked<Idx> {
-    type Output: ?Sized;
-
-    /// Gets a reference to the element at the given index.
-    ///
-    /// If `idx` is not in bounds, a panic occurs in debug mode and Undefined
-    /// Behavior occurs in release mode.
-    ///
-    /// # Safety
-    ///
-    /// - `idx` must be in bounds.
-    #[track_caller]
-    unsafe fn get_debug_checked(&self, idx: Idx) -> &Self::Output;
-    /// Gets a mutable reference to the element at the given index.
-    ///
-    /// If `idx` is not in bounds, a panic occurs in debug mode and Undefined
-    /// Behavior occurs in release mode.
-    ///
-    /// # Safety
-    ///
-    /// - `idx` must be in bounds.
-    #[track_caller]
-    unsafe fn get_debug_checked_mut(&mut self, idx: Idx) -> &mut Self::Output;
-}
-
-impl<T, I> GetDebugChecked<I> for [T]
-where
-    I: SliceIndex<[T]>,
-{
-    type Output = I::Output;
-
-    unsafe fn get_debug_checked(&self, idx: I) -> &Self::Output {
-        #[cfg(debug_assertions)]
-        return &self[idx];
-
-        #[cfg(not(debug_assertions))]
-        return self.get_unchecked(idx);
-    }
-
-    unsafe fn get_debug_checked_mut(&mut self, idx: I) -> &mut Self::Output {
-        #[cfg(debug_assertions)]
-        return &mut self[idx];
-
-        #[cfg(not(debug_assertions))]
-        return self.get_unchecked_mut(idx);
-    }
-}
-
-// Don't use `Slab::get_unchecked` because there's a panicking branch. https://github.com/tokio-rs/slab/pull/74
-impl<T> GetDebugChecked<usize> for Slab<T> {
-    type Output = T;
-
-    #[inline]
-    unsafe fn get_debug_checked(&self, idx: usize) -> &Self::Output {
-        self.get(idx).expect_debug_checked("invalid slab key")
-    }
-
-    #[inline]
-    unsafe fn get_debug_checked_mut(&mut self, idx: usize) -> &mut Self::Output {
-        self.get_mut(idx).expect_debug_checked("invalid slab key")
-    }
-}
-
-/// Extension trait for checked unwrapping with checks removed in release
-/// mode.
-pub(crate) trait UnwrapDebugChecked {
-    type Output;
-
-    /// Consumes `self` and returns the inner value.
-    ///
-    /// # Safety
-    ///
-    /// - Must successfully unwrap (`Some` in `Option`, `Ok` in `Result`, etc.)
-    #[track_caller]
-    unsafe fn unwrap_debug_checked(self) -> Self::Output;
-    /// Like [`Self::unwrap_debug_checked`] but panics with the given error
-    /// message. The message is ignored in release mode.
-    ///
-    /// # Safety
-    ///
-    /// - Must successfully unwrap (`Some` in `Option`, `Ok` in `Result`, etc.)
-    #[track_caller]
-    unsafe fn expect_debug_checked(self, msg: &str) -> Self::Output;
-}
-
-impl<T> UnwrapDebugChecked for Option<T> {
-    type Output = T;
-
-    #[inline]
-    unsafe fn unwrap_debug_checked(self) -> Self::Output {
-        #[cfg(debug_assertions)]
-        return self.unwrap();
-
-        #[cfg(not(debug_assertions))]
-        return self.unwrap_unchecked();
-    }
-
-    #[inline]
-    unsafe fn expect_debug_checked(self, msg: &str) -> Self::Output {
-        #[cfg(debug_assertions)]
-        return self.expect(msg);
-
-        #[cfg(not(debug_assertions))]
-        {
-            let _ = msg;
-            return self.unwrap_unchecked();
-        }
-    }
-}
-
-impl<T, E> UnwrapDebugChecked for Result<T, E>
-where
-    E: fmt::Debug,
-{
-    type Output = T;
-
-    #[inline]
-    unsafe fn unwrap_debug_checked(self) -> Self::Output {
-        #[cfg(debug_assertions)]
-        return self.unwrap();
-
-        #[cfg(not(debug_assertions))]
-        return self.unwrap_unchecked();
-    }
-
-    #[inline]
-    unsafe fn expect_debug_checked(self, msg: &str) -> Self::Output {
-        #[cfg(debug_assertions)]
-        return self.expect(msg);
-
-        #[cfg(not(debug_assertions))]
-        {
-            let _ = msg;
-            return self.unwrap_unchecked();
-        }
-    }
-}
-
 #[inline]
 #[track_caller]
-pub(crate) unsafe fn unreachable_debug_checked() -> ! {
-    #[cfg(debug_assertions)]
-    unreachable!();
-
-    #[cfg(not(debug_assertions))]
-    core::hint::unreachable_unchecked();
-}
-
-#[inline]
-#[track_caller]
-pub(crate) unsafe fn assume_debug_checked(cond: bool) {
+pub(crate) unsafe fn assume_unchecked(cond: bool) {
     if !cond {
-        unreachable_debug_checked()
+        core::hint::unreachable_unchecked()
     }
 }
 

--- a/src/bit_set.rs
+++ b/src/bit_set.rs
@@ -8,7 +8,6 @@ use core::marker::PhantomData;
 use core::ops::{BitOr, BitOrAssign, BitXor, BitXorAssign};
 use core::{any, fmt};
 
-use crate::assert::GetDebugChecked;
 use crate::sparse::SparseIndex;
 
 /// A set data structure backed by a vector of bits.
@@ -60,7 +59,7 @@ impl<T> BitSet<T> {
         }
 
         // SAFETY: Block index is in bounds due to check above.
-        unsafe { self.blocks.get_debug_checked_mut(block_idx) }
+        unsafe { self.blocks.get_unchecked_mut(block_idx) }
     }
 
     /// Returns `true` if `self` has no elements in common with `other`.

--- a/src/blob_vec.rs
+++ b/src/blob_vec.rs
@@ -102,8 +102,7 @@ impl BlobVec {
         }
 
         Some(unsafe {
-            NonNull::new(self.data.as_ptr().add(idx * self.elem_layout.size()))
-                .unwrap_unchecked()
+            NonNull::new(self.data.as_ptr().add(idx * self.elem_layout.size())).unwrap_unchecked()
         })
     }
 

--- a/src/blob_vec.rs
+++ b/src/blob_vec.rs
@@ -3,7 +3,6 @@ use core::alloc::Layout;
 use core::ptr;
 use core::ptr::NonNull;
 
-use crate::assert::UnwrapDebugChecked;
 use crate::drop::DropFn;
 use crate::layout_util::pad_to_align;
 
@@ -104,7 +103,7 @@ impl BlobVec {
 
         Some(unsafe {
             NonNull::new(self.data.as_ptr().add(idx * self.elem_layout.size()))
-                .unwrap_debug_checked()
+                .unwrap_unchecked()
         })
     }
 
@@ -210,7 +209,7 @@ impl BlobVec {
     pub(crate) fn capacity_layout(&self) -> Layout {
         unsafe {
             Layout::from_size_align(self.elem_layout.size() * self.cap, self.elem_layout.align())
-                .unwrap_debug_checked()
+                .unwrap_unchecked()
         }
     }
 

--- a/src/component.rs
+++ b/src/component.rs
@@ -10,7 +10,6 @@ use ahash::RandomState;
 pub use evenio_macros::Component;
 
 use crate::archetype::{Archetype, ArchetypeIdx};
-use crate::assert::UnwrapDebugChecked;
 use crate::drop::DropFn;
 use crate::entity::EntityLocation;
 use crate::event::{Event, EventId, EventPtr};
@@ -120,7 +119,7 @@ impl Components {
     /// `None` if the `TypeId` does not map to a component.
     pub fn get_by_type_id(&self, type_id: TypeId) -> Option<&ComponentInfo> {
         let id = *self.by_type_id.get(&type_id)?;
-        Some(unsafe { self.get(id).unwrap_debug_checked() })
+        Some(unsafe { self.get(id).unwrap_unchecked() })
     }
 
     /// Does the given component exist in the world?

--- a/src/event.rs
+++ b/src/event.rs
@@ -19,9 +19,7 @@ pub use evenio_macros::Event;
 
 use crate::access::Access;
 use crate::archetype::Archetype;
-use crate::assert::{
-    AssertMutable, AssertTargetedEvent, AssertUntargetedEvent, GetDebugChecked, UnwrapDebugChecked,
-};
+use crate::assert::{AssertMutable, AssertTargetedEvent, AssertUntargetedEvent};
 use crate::component::ComponentIdx;
 use crate::drop::DropFn;
 use crate::entity::{EntityId, EntityLocation};
@@ -138,7 +136,7 @@ impl Events {
         debug_assert_ne!(type_id, TypeId::of::<SpawnQueued>());
 
         let idx = *self.by_type_id.get(&type_id)?;
-        Some(unsafe { self.get(idx).unwrap_debug_checked() })
+        Some(unsafe { self.get(idx).unwrap_unchecked() })
     }
 
     /// Does the given event exist in the world?
@@ -664,7 +662,7 @@ impl EventQueue {
     ///
     /// `from` must be in bounds.
     pub(crate) unsafe fn reverse_from(&mut self, from: usize) {
-        self.items.get_debug_checked_mut(from..).reverse();
+        self.items.get_unchecked_mut(from..).reverse();
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = &EventQueueItem> {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -764,7 +764,7 @@ mod rayon_impl {
                 .zip_eq(self.arch_indices)
                 .flat_map(|(state, &index)| {
                     let entity_count =
-                        unsafe { self.archetypes.get(index).unwrap_debug_checked() }.entity_count();
+                        unsafe { self.archetypes.get(index).unwrap_unchecked() }.entity_count();
 
                     (0..entity_count).into_par_iter().map(|row| {
                         let item: Q::Item<'a> = unsafe { Q::get(state, ArchetypeRow(row)) };

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -8,7 +8,7 @@ use core::ptr::NonNull;
 use core::{any, fmt};
 
 use crate::archetype::{Archetype, ArchetypeIdx, ArchetypeRow, Archetypes};
-use crate::assert::{assume_debug_checked, UnwrapDebugChecked};
+use crate::assert::assume_unchecked;
 use crate::entity::{Entities, EntityId, EntityLocation};
 use crate::event::EventPtr;
 use crate::handler::{HandlerConfig, HandlerInfo, HandlerParam, InitError};
@@ -50,7 +50,7 @@ impl<Q: Query> FetcherState<Q> {
         };
 
         // Eliminate a branch in `SparseMap::get`.
-        assume_debug_checked(loc.archetype != ArchetypeIdx::NULL);
+        assume_unchecked(loc.archetype != ArchetypeIdx::NULL);
 
         let Some(state) = self.map.get(loc.archetype) else {
             return Err(GetError::QueryDoesNotMatch);
@@ -99,10 +99,8 @@ impl<Q: Query> FetcherState<Q> {
 
     #[inline]
     pub(crate) unsafe fn get_by_location_mut(&mut self, loc: EntityLocation) -> Q::Item<'_> {
-        let state = self
-            .map
-            .get(loc.archetype)
-            .expect_debug_checked("invalid entity location");
+        // SAFETY: Caller ensures location is valid.
+        let state = self.map.get(loc.archetype).unwrap_unchecked();
         Q::get(state, loc.row)
     }
 
@@ -123,7 +121,7 @@ impl<Q: Query> FetcherState<Q> {
         let indices = self.map.keys();
         let states = self.map.values();
 
-        assume_debug_checked(indices.len() == states.len());
+        assume_unchecked(indices.len() == states.len());
 
         if states.is_empty() {
             Iter {
@@ -138,14 +136,11 @@ impl<Q: Query> FetcherState<Q> {
             let start = states.as_ptr().cast_mut();
             let end = start.add(states.len() - 1);
             Iter {
-                state: NonNull::new(start).unwrap_debug_checked(),
-                state_last: NonNull::new(end).unwrap_debug_checked(),
-                index: NonNull::new(indices.as_ptr().cast_mut()).unwrap_debug_checked(),
+                state: NonNull::new(start).unwrap_unchecked(),
+                state_last: NonNull::new(end).unwrap_unchecked(),
+                index: NonNull::new(indices.as_ptr().cast_mut()).unwrap_unchecked(),
                 row: ArchetypeRow(0),
-                len: archetypes
-                    .get(indices[0])
-                    .unwrap_debug_checked()
-                    .entity_count(),
+                len: archetypes.get(indices[0]).unwrap_unchecked().entity_count(),
                 archetypes,
             }
         }
@@ -609,13 +604,13 @@ impl<'a, Q: Query> Iterator for Iter<'a, Q> {
             self.index = unsafe { NonNull::new_unchecked(self.index.as_ptr().add(1)) };
 
             let idx = unsafe { *self.index.as_ptr() };
-            let arch = unsafe { self.archetypes.get(idx).unwrap_debug_checked() };
+            let arch = unsafe { self.archetypes.get(idx).unwrap_unchecked() };
 
             self.row = ArchetypeRow(0);
             self.len = arch.entity_count();
 
             // SAFETY: Fetcher state only contains nonempty archetypes.
-            unsafe { assume_debug_checked(self.len > 0) };
+            unsafe { assume_unchecked(self.len > 0) };
         }
 
         let state = unsafe { &*self.state.as_ptr().cast_const() };
@@ -646,8 +641,7 @@ impl<Q: Query> ExactSizeIterator for Iter<'_, Q> {
         while index != index_last {
             index = unsafe { index.add(1) };
 
-            remaining +=
-                unsafe { self.archetypes.get(*index).unwrap_debug_checked() }.entity_count();
+            remaining += unsafe { self.archetypes.get(*index).unwrap_unchecked() }.entity_count();
         }
 
         remaining as usize
@@ -763,7 +757,7 @@ mod rayon_impl {
         where
             C: UnindexedConsumer<Self::Item>,
         {
-            unsafe { assume_debug_checked(self.arch_states.len() == self.arch_indices.len()) };
+            unsafe { assume_unchecked(self.arch_states.len() == self.arch_indices.len()) };
 
             self.arch_states
                 .par_iter()

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -18,7 +18,6 @@ pub use evenio_macros::HandlerParam;
 use crate::access::{Access, ComponentAccess};
 use crate::aliased_box::AliasedBox;
 use crate::archetype::Archetype;
-use crate::assert::UnwrapDebugChecked;
 use crate::bit_set::BitSet;
 use crate::component::ComponentIdx;
 use crate::entity::EntityLocation;
@@ -1193,11 +1192,8 @@ where
         target_location: EntityLocation,
         world: UnsafeWorldCell,
     ) {
-        let state = unsafe {
-            self.state
-                .as_mut()
-                .expect_debug_checked("handler must be initialized")
-        };
+        // Handler must be initialized.
+        let state = unsafe { self.state.as_mut().unwrap_unchecked() };
 
         let param =
             <F::Param as HandlerParam>::get(state, handler_info, event_ptr, target_location, world);
@@ -1205,21 +1201,15 @@ where
     }
 
     fn refresh_archetype(&mut self, arch: &Archetype) {
-        let state = unsafe {
-            self.state
-                .as_mut()
-                .expect_debug_checked("handler must be initialized")
-        };
+        // Handler must be initialized.
+        let state = unsafe { self.state.as_mut().unwrap_unchecked() };
 
         F::Param::refresh_archetype(state, arch)
     }
 
     fn remove_archetype(&mut self, arch: &Archetype) {
-        let state = unsafe {
-            self.state
-                .as_mut()
-                .expect_debug_checked("handler must be initialized")
-        };
+        // Handler must be initialized.
+        let state = unsafe { self.state.as_mut().unwrap_unchecked() };
 
         F::Param::remove_archetype(state, arch)
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -12,7 +12,7 @@ pub use evenio_macros::Query;
 
 use crate::access::{Access, ComponentAccess};
 use crate::archetype::{Archetype, ArchetypeRow};
-use crate::assert::{AssertMutable, UnwrapDebugChecked};
+use crate::assert::AssertMutable;
 use crate::component::{Component, ComponentIdx};
 use crate::entity::EntityId;
 use crate::handler::{HandlerConfig, InitError};
@@ -724,7 +724,7 @@ unsafe impl Query for EntityId {
 
     fn new_arch_state(arch: &Archetype, (): &mut Self::State) -> Option<Self::ArchState> {
         Some(unsafe {
-            ColumnPtr(NonNull::new(arch.entity_ids().as_ptr().cast_mut()).unwrap_debug_checked())
+            ColumnPtr(NonNull::new(arch.entity_ids().as_ptr().cast_mut()).unwrap_unchecked())
         })
     }
 

--- a/src/slot_map.rs
+++ b/src/slot_map.rs
@@ -6,8 +6,6 @@ use core::num::{NonZeroU32, NonZeroU64};
 use core::ops::{Index, IndexMut};
 use core::{fmt, mem};
 
-use crate::assert::UnwrapDebugChecked;
-
 #[derive(Clone, Debug)]
 pub(crate) struct SlotMap<T> {
     slots: Vec<Slot<T>>,
@@ -38,7 +36,7 @@ impl<T> SlotMap<T> {
             debug_assert!(slot.is_vacant());
 
             // SAFETY: Generation doesn't overflow because it's even.
-            key = unsafe { Key::new(self.next_free, slot.generation + 1).unwrap_debug_checked() };
+            key = unsafe { Key::new(self.next_free, slot.generation + 1).unwrap_unchecked() };
 
             // Get value before modifying the slot in case `f` unwinds.
             let value = f(key);

--- a/src/sparse_map.rs
+++ b/src/sparse_map.rs
@@ -2,7 +2,7 @@
 use alloc::{vec, vec::Vec};
 use core::mem;
 
-use crate::assert::{assume_debug_checked, GetDebugChecked};
+use crate::assert::assume_unchecked;
 use crate::sparse::SparseIndex;
 
 #[derive(Clone, Default, Debug)]
@@ -30,7 +30,7 @@ impl<K: SparseIndex, V> SparseMap<K, V> {
         if idx >= K::MAX.index() {
             None
         } else {
-            let value = unsafe { self.dense.get_debug_checked(idx) };
+            let value = unsafe { self.dense.get_unchecked(idx) };
             Some(value)
         }
     }
@@ -47,7 +47,7 @@ impl<K: SparseIndex, V> SparseMap<K, V> {
         if idx >= K::MAX.index() {
             None
         } else {
-            let value = unsafe { self.dense.get_debug_checked_mut(idx) };
+            let value = unsafe { self.dense.get_unchecked_mut(idx) };
             Some(value)
         }
     }
@@ -69,7 +69,7 @@ impl<K: SparseIndex, V> SparseMap<K, V> {
 
         // SAFETY: We resized the vec so that `sparse_idx` is in bounds.
         let dense_len = self.dense.len();
-        let dense_idx = unsafe { self.sparse.get_debug_checked_mut(sparse_idx) };
+        let dense_idx = unsafe { self.sparse.get_unchecked_mut(sparse_idx) };
 
         if dense_idx.index() == K::MAX.index() {
             *dense_idx = K::from_index(dense_len);
@@ -81,7 +81,7 @@ impl<K: SparseIndex, V> SparseMap<K, V> {
         } else {
             let idx = dense_idx.index();
             // SAFETY: Data structure ensures all non-max dense indices are in bounds.
-            let v = unsafe { self.dense.get_debug_checked_mut(idx) };
+            let v = unsafe { self.dense.get_unchecked_mut(idx) };
 
             Some(mem::replace(v, value))
         }
@@ -94,16 +94,16 @@ impl<K: SparseIndex, V> SparseMap<K, V> {
         if dense_idx == K::MAX.index() {
             None
         } else {
-            unsafe { assume_debug_checked(dense_idx < self.dense.len()) };
+            unsafe { assume_unchecked(dense_idx < self.dense.len()) };
 
             let res = self.dense.swap_remove(dense_idx);
 
-            unsafe { assume_debug_checked(dense_idx < self.indices.len()) };
+            unsafe { assume_unchecked(dense_idx < self.indices.len()) };
 
             self.indices.swap_remove(dense_idx);
 
             if let Some(&moved_index) = self.indices.get(dense_idx) {
-                *unsafe { self.sparse.get_debug_checked_mut(moved_index.index()) } =
+                *unsafe { self.sparse.get_unchecked_mut(moved_index.index()) } =
                     K::from_index(dense_idx);
             }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -11,7 +11,7 @@ use core::ptr::NonNull;
 
 use crate::access::ComponentAccess;
 use crate::archetype::Archetypes;
-use crate::assert::{AssertMutable, UnwrapDebugChecked};
+use crate::assert::AssertMutable;
 use crate::component::{
     AddComponent, Component, ComponentDescriptor, ComponentId, ComponentInfo, Components,
     RemoveComponent,
@@ -215,7 +215,7 @@ impl World {
             .id()
             .index();
 
-        let arch = unsafe { self.archetypes().get(loc.archetype).unwrap_debug_checked() };
+        let arch = unsafe { self.archetypes().get(loc.archetype).unwrap_unchecked() };
 
         let col = arch.column_of(component_idx)?;
 
@@ -258,7 +258,7 @@ impl World {
             .id()
             .index();
 
-        let arch = unsafe { self.archetypes().get(loc.archetype).unwrap_debug_checked() };
+        let arch = unsafe { self.archetypes().get(loc.archetype).unwrap_unchecked() };
 
         let col = arch.column_of(component_idx)?;
 
@@ -797,7 +797,7 @@ impl World {
             let event_info = unsafe {
                 self.events
                     .get_by_index(event_meta.event_idx())
-                    .unwrap_debug_checked()
+                    .unwrap_unchecked()
             };
             let event_kind = event_info.kind();
 
@@ -853,7 +853,7 @@ impl World {
                             self.world
                                 .events
                                 .get_by_index(item.meta.event_idx())
-                                .unwrap_debug_checked()
+                                .unwrap_unchecked()
                         };
 
                         if let Some(drop) = info.drop() {
@@ -878,7 +878,7 @@ impl World {
                         ctx.world
                             .handlers
                             .get_untargeted_list(idx)
-                            .unwrap_debug_checked()
+                            .unwrap_unchecked()
                     },
                     EntityLocation::NULL,
                 ),
@@ -893,7 +893,7 @@ impl World {
                         ctx.world
                             .archetypes
                             .get(location.archetype)
-                            .unwrap_debug_checked()
+                            .unwrap_unchecked()
                     };
 
                     static EMPTY: HandlerList = HandlerList::new();


### PR DESCRIPTION
Rust 1.78.0 added debug checks for the standard `*_unchecked` functions when `#[cfg(debug_assertions)]` is on, so our custom extension traits are no longer necessary.