### PR TITLE
feat: SyncUnsafeCell query

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(sync_unsafe_cell)]
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![warn(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]


### PR DESCRIPTION
This currently requires nightly. Maybe we could make our own `SyncUnsafeCell`?

anyway, this type of thing can be useful for when I want to use `Fetcher` inside of a `ParallelIterator` and I know I have enforced invariants such that I will never be mutably accessing the same element from two places at once.

This is the big use case I can think of and `UnsafeCell` will probs not be happy since it is not `Sync` but `SyncUnsafeCell` would be.