### PR TITLE
Add `Fetcher::get_unchecked`

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -232,6 +232,20 @@ impl<'a, Q: Query> Fetcher<'a, Q> {
         unsafe { self.state.get_unchecked(self.world.entities(), entity) }
     }
 
+    /// Returns the query item for the given entity without checking borrowing
+    /// rules.
+    ///
+    /// This is useful when you know the entity IDs are disjoint but can't prove
+    /// it to the compiler.
+    ///
+    /// # Safety
+    ///
+    /// You must ensure that all entities that co-occur are disjoint if they
+    /// contain any mutable references
+    pub unsafe fn get_unchecked(&self, entity: EntityId) -> Result<Q::Item<'_>, GetError> {
+        unsafe { self.state.get_unchecked(self.world.entities(), entity) }
+    }
+
     /// Returns the query item for the given entity.
     ///
     /// If the entity doesn't exist or doesn't match the query, then a


### PR DESCRIPTION
- useful when you know the entity IDs are disjoint but can't prove it to the compiler.
- Closes #54