### PR TITLE
Fix `#[derive(Event)]` on generic types with type params.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `Sender` now has allocation methods and can send events with data borrowed from the allocator.
 - `Sender` is now entirely internally mutable and all methods take `&self`.
 - Changed API of `UnsafeWorldCell`.
+- Deriving `GlobalEvent` or `TargetedEvent` on a type with generic type params now succeeds (with caveats).
 
 ## 0.6.0 - 2024-05-18
 

--- a/evenio_macros/src/event.rs
+++ b/evenio_macros/src/event.rs
@@ -5,7 +5,11 @@ use syn::{parse2, parse_quote, DeriveInput, Result, Type};
 use crate::util::{parse_attr_immutable, replace_lifetime};
 
 pub(crate) fn derive_event(input: TokenStream, is_targeted: bool) -> Result<TokenStream> {
-    let input = parse2::<DeriveInput>(input)?;
+    let mut input = parse2::<DeriveInput>(input)?;
+
+    for ty in input.generics.type_params_mut() {
+        ty.bounds.push(parse_quote!('static));
+    }
 
     let mutability_type: Type = if parse_attr_immutable("event", &input.attrs)? {
         parse_quote!(::evenio::mutability::Immutable)

--- a/src/event.rs
+++ b/src/event.rs
@@ -1348,7 +1348,7 @@ mod tests {
         world.send(A(123));
     }
 
-    #[allow(unused)]
+    #[allow(unused, clippy::type_complexity)]
     mod derive_event {
         use core::marker::PhantomData;
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1347,4 +1347,33 @@ mod tests {
 
         world.send(A(123));
     }
+
+    #[allow(unused)]
+    mod derive_event {
+        use core::marker::PhantomData;
+
+        use super::*;
+
+        #[derive(GlobalEvent)]
+        struct StructWithLifetime_<'a> {
+            _ignore: &'a (),
+        }
+
+        #[derive(TargetedEvent)]
+        struct StructWithLifetime<'a> {
+            _ignore: &'a (),
+        }
+
+        #[derive(GlobalEvent)]
+        struct StructWithGenericType_<T>(T);
+
+        #[derive(TargetedEvent)]
+        struct StructWithGenericType<T>(T);
+
+        #[derive(GlobalEvent)]
+        struct StructWithBoth_<'a, T>(PhantomData<(fn() -> T, &'a ())>);
+
+        #[derive(TargetedEvent)]
+        struct StructWithBoth<'a, T>(PhantomData<(fn() -> T, &'a ())>);
+    }
 }

--- a/src/event/global.rs
+++ b/src/event/global.rs
@@ -21,7 +21,7 @@ use crate::world::{UnsafeWorldCell, World};
 /// `Event<EventIdx = GlobalEventIdx>`. Use the derive macro to create the
 /// appropriate implementation of [`Event`].
 ///
-/// Note that this trait is intended to be mutually exclusive with
+/// This trait is intended to be mutually exclusive with
 /// [`TargetedEvent`](super::TargetedEvent).
 ///
 /// # Deriving
@@ -33,6 +33,17 @@ use crate::world::{UnsafeWorldCell, World};
 /// struct MyEvent {
 ///     example_data: i32,
 /// }
+/// ```
+///
+/// Due to language limitations, types with generic type params will
+/// have a `T: 'static` bound in the generated impl.
+///
+/// ```
+/// use evenio::prelude::*;
+///
+/// // `T: 'static` is required for this to impl `Event`.
+/// #[derive(GlobalEvent)]
+/// struct TypeWithGeneric<T>(T);
 /// ```
 pub trait GlobalEvent: Event<EventIdx = GlobalEventIdx> {}
 impl<E: Event<EventIdx = GlobalEventIdx>> GlobalEvent for E {}

--- a/src/event/targeted.rs
+++ b/src/event/targeted.rs
@@ -22,8 +22,7 @@ use crate::world::{UnsafeWorldCell, World};
 /// `Event<EventIdx = TargetedEventIdx>`. Use the derive macro to create the
 /// appropriate implementation of [`Event`].
 ///
-/// Note that this trait is intended to be mutually exclusive with
-/// [`GlobalEvent`].
+/// This trait is intended to be mutually exclusive with [`GlobalEvent`].
 ///
 /// # Deriving
 ///
@@ -34,6 +33,17 @@ use crate::world::{UnsafeWorldCell, World};
 /// struct MyEvent {
 ///     example_data: i32,
 /// }
+/// ```
+///
+/// Due to language limitations, types with generic type params will
+/// have a `T: 'static` bound in the generated impl.
+///
+/// ```
+/// use evenio::prelude::*;
+///
+/// // `T: 'static` is required for this to impl `Event`.
+/// #[derive(TargetedEvent)]
+/// struct TypeWithGeneric<T>(T);
 /// ```
 pub trait TargetedEvent: Event<EventIdx = TargetedEventIdx> {}
 impl<E: Event<EventIdx = TargetedEventIdx>> TargetedEvent for E {}


### PR DESCRIPTION
This PR allows the following code to compile.

```rust
#[derive(GlobalEvent)]
struct StructWithGenericType<T>(T);
```

The problem is the `This<'a>` associated type requires `T` to outlive `'a`, but there's no way to actually specify that in the impl. As a fix, we add `'static` bounds to all generic params.

AFAICT this isn't truly fixable unless Rust adds higher-kinded polymorphism, which isn't happening any time soon. Alternatively, Rust could remove the `'static` requirement from `TypeId::of` which would let us delete `This`.