### PR TITLE
Improve ergonomics of `Single` and `TrySingle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `Sender` is now entirely internally mutable and all methods take `&self`.
 - Changed API of `UnsafeWorldCell`.
 - Deriving `GlobalEvent` or `TargetedEvent` on a type with generic type params now succeeds (with caveats).
+- Improved ergonomics of `Single` and `TrySingle`. `Single` no longer has a lifetime param, `Deref` impls are improved, and `TrySingle` is an alias for `Result`.
 
 ## 0.6.0 - 2024-05-18
 

--- a/evenio_macros/src/query.rs
+++ b/evenio_macros/src/query.rs
@@ -43,12 +43,12 @@ pub(crate) fn derive_query(input: TokenStream) -> Result<TokenStream> {
                 }
 
                 where_clause.predicates.push(
-                    parse_quote!(#ty: for<'__a> ::evenio::query::Query<Item<'__a> = #replaced_ty>),
+                    parse_quote!(#ty: for<'__a> ::evenio::query::Query<This<'__a> = #replaced_ty>),
                 );
 
                 ro_where_clause
                     .predicates
-                    .push(parse_quote!(#ty: for<'__a> ::evenio::query::ReadOnlyQuery<Item<'__a> = #replaced_ty>));
+                    .push(parse_quote!(#ty: for<'__a> ::evenio::query::ReadOnlyQuery<This<'__a> = #replaced_ty>));
             }
 
             get_body = match &struct_.fields {
@@ -106,15 +106,15 @@ pub(crate) fn derive_query(input: TokenStream) -> Result<TokenStream> {
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    let mut item: Type = parse_quote!(#name #ty_generics);
+    let mut this: Type = parse_quote!(#name #ty_generics);
     for life in &lifetimes {
-        replace_lifetime(&mut item, &life.lifetime.ident, &parse_quote!(__a));
+        replace_lifetime(&mut this, &life.lifetime.ident, &parse_quote!(__a));
     }
 
     Ok(quote! {
         #[automatically_derived]
         unsafe impl #impl_generics ::evenio::query::Query for #name #ty_generics #where_clause {
-            type Item<'__a> = #item;
+            type This<'__a> = #this;
 
             type ArchState = <#tuple_ty as ::evenio::query::Query>::ArchState;
 
@@ -136,7 +136,7 @@ pub(crate) fn derive_query(input: TokenStream) -> Result<TokenStream> {
                 <#tuple_ty as ::evenio::query::Query>::new_arch_state(arch, state)
             }
 
-            unsafe fn get<'__a>(state: &Self::ArchState, row: ::evenio::archetype::ArchetypeRow) -> Self::Item<'__a> {
+            unsafe fn get<'__a>(state: &Self::ArchState, row: ::evenio::archetype::ArchetypeRow) -> Self::This<'__a> {
                 #get_body
             }
         }

--- a/src/event.rs
+++ b/src/event.rs
@@ -463,7 +463,7 @@ where
     E: TargetedEvent,
     E::This<'a>: fmt::Debug,
     Q: Query,
-    Q::Item<'a>: fmt::Debug,
+    Q::This<'a>: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Receiver")
@@ -584,7 +584,7 @@ where
     E: TargetedEvent,
     E::This<'a>: fmt::Debug,
     Q: Query,
-    Q::Item<'a>: fmt::Debug,
+    Q::This<'a>: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Receiver")
@@ -612,7 +612,7 @@ impl ReceiverQuery for NullReceiverQuery {
 }
 
 impl<Q: Query> ReceiverQuery for Q {
-    type Item<'a> = Q::Item<'a>;
+    type Item<'a> = Q::This<'a>;
 }
 
 mod null_receiver_query {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -489,10 +489,7 @@ unsafe impl<Q: Query + 'static> HandlerParam for Single<Q> {
     }
 }
 
-impl<'a, T> Deref for Single<&'a T>
-where
-    &'a T: for<'b> Query<This<'b> = &'b T>,
-{
+impl<'a, T> Deref for Single<&'a T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -500,10 +497,7 @@ where
     }
 }
 
-impl<'a, T> Deref for Single<&'a mut T>
-where
-    &'a mut T: for<'b> Query<This<'b> = &'b mut T>,
-{
+impl<'a, T> Deref for Single<&'a mut T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -511,10 +505,7 @@ where
     }
 }
 
-impl<'a, T> DerefMut for Single<&'a mut T>
-where
-    &'a mut T: for<'b> Query<This<'b> = &'b mut T>,
-{
+impl<'a, T> DerefMut for Single<&'a mut T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
     }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -759,9 +759,9 @@ mod rayon_impl {
     impl<'a, Q> ParallelIterator for ParIter<'a, Q>
     where
         Q: Query,
-        Q::Item<'a>: Send,
+        Q::This<'a>: Send,
     {
-        type Item = Q::Item<'a>;
+        type Item = Q::This<'a>;
 
         fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where
@@ -777,7 +777,7 @@ mod rayon_impl {
                         unsafe { self.archetypes.get(index).unwrap_unchecked() }.entity_count();
 
                     (0..entity_count).into_par_iter().map(|row| {
-                        let item: Q::Item<'a> = unsafe { Q::get(state, ArchetypeRow(row)) };
+                        let item: Q::This<'a> = unsafe { Q::get(state, ArchetypeRow(row)) };
                         item
                     })
                 })
@@ -789,11 +789,11 @@ mod rayon_impl {
     impl<'a, Q> IntoParallelIterator for Fetcher<'a, Q>
     where
         Q: Query,
-        Q::Item<'a>: Send,
+        Q::This<'a>: Send,
     {
         type Iter = ParIter<'a, Q>;
 
-        type Item = Q::Item<'a>;
+        type Item = Q::This<'a>;
 
         fn into_par_iter(self) -> Self::Iter {
             unsafe { self.state.par_iter_mut(self.world.archetypes()) }
@@ -804,11 +804,11 @@ mod rayon_impl {
     impl<'a, Q> IntoParallelIterator for &'a Fetcher<'_, Q>
     where
         Q: ReadOnlyQuery,
-        Q::Item<'a>: Send,
+        Q::This<'a>: Send,
     {
         type Iter = ParIter<'a, Q>;
 
-        type Item = Q::Item<'a>;
+        type Item = Q::This<'a>;
 
         fn into_par_iter(self) -> Self::Iter {
             unsafe { self.state.par_iter(self.world.archetypes()) }
@@ -819,11 +819,11 @@ mod rayon_impl {
     impl<'a, Q: Query> IntoParallelIterator for &'a mut Fetcher<'_, Q>
     where
         Q: Query,
-        Q::Item<'a>: Send,
+        Q::This<'a>: Send,
     {
         type Iter = ParIter<'a, Q>;
 
-        type Item = Q::Item<'a>;
+        type Item = Q::This<'a>;
 
         fn into_par_iter(self) -> Self::Iter {
             unsafe { self.state.par_iter_mut(self.world.archetypes()) }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -44,7 +44,7 @@ impl<Q: Query> FetcherState<Q> {
         &self,
         entities: &Entities,
         entity: EntityId,
-    ) -> Result<Q::Item<'_>, GetError> {
+    ) -> Result<Q::This<'_>, GetError> {
         let Some(loc) = entities.get(entity) else {
             return Err(GetError::NoSuchEntity);
         };
@@ -64,7 +64,7 @@ impl<Q: Query> FetcherState<Q> {
         &mut self,
         entities: &Entities,
         array: [EntityId; N],
-    ) -> Result<[Q::Item<'_>; N], GetManyMutError> {
+    ) -> Result<[Q::This<'_>; N], GetManyMutError> {
         // Check for overlapping entity ids.
         for i in 0..N {
             for j in 0..i {
@@ -74,13 +74,13 @@ impl<Q: Query> FetcherState<Q> {
             }
         }
 
-        let mut res: [MaybeUninit<Q::Item<'_>>; N] = [(); N].map(|()| MaybeUninit::uninit());
+        let mut res: [MaybeUninit<Q::This<'_>>; N] = [(); N].map(|()| MaybeUninit::uninit());
 
         for i in 0..N {
             match self.get_unchecked(entities, array[i]) {
                 Ok(item) => res[i] = MaybeUninit::new(item),
                 Err(e) => {
-                    if mem::needs_drop::<Q::Item<'_>>() {
+                    if mem::needs_drop::<Q::This<'_>>() {
                         for item in res.iter_mut().take(i) {
                             item.assume_init_drop();
                         }
@@ -92,13 +92,13 @@ impl<Q: Query> FetcherState<Q> {
         }
 
         Ok(mem::transmute_copy::<
-            [MaybeUninit<Q::Item<'_>>; N],
-            [Q::Item<'_>; N],
+            [MaybeUninit<Q::This<'_>>; N],
+            [Q::This<'_>; N],
         >(&res))
     }
 
     #[inline]
-    pub(crate) unsafe fn get_by_location_mut(&mut self, loc: EntityLocation) -> Q::Item<'_> {
+    pub(crate) unsafe fn get_by_location_mut(&mut self, loc: EntityLocation) -> Q::This<'_> {
         // SAFETY: Caller ensures location is valid.
         let state = self.map.get(loc.archetype).unwrap_unchecked();
         Q::get(state, loc.row)
@@ -189,14 +189,14 @@ impl<Q: Query> FetcherState<Q> {
 unsafe impl<'a, Q> Send for Fetcher<'a, Q>
 where
     Q: Query,
-    Q::Item<'a>: Send,
+    Q::This<'a>: Send,
 {
 }
 
 unsafe impl<'a, Q> Sync for Fetcher<'a, Q>
 where
     Q: Query,
-    Q::Item<'a>: Sync,
+    Q::This<'a>: Sync,
 {
 }
 
@@ -225,7 +225,7 @@ impl<'a, Q: Query> Fetcher<'a, Q> {
     /// If the entity doesn't exist or doesn't match the query, then a
     /// [`GetError`] is returned.
     #[inline]
-    pub fn get(&self, entity: EntityId) -> Result<Q::Item<'_>, GetError>
+    pub fn get(&self, entity: EntityId) -> Result<Q::This<'_>, GetError>
     where
         Q: ReadOnlyQuery,
     {
@@ -245,7 +245,7 @@ impl<'a, Q: Query> Fetcher<'a, Q> {
     ///
     /// You must ensure that all entities that co-occur are disjoint if they
     /// contain any mutable references.
-    pub unsafe fn get_unchecked(&self, entity: EntityId) -> Result<Q::Item<'_>, GetError> {
+    pub unsafe fn get_unchecked(&self, entity: EntityId) -> Result<Q::This<'_>, GetError> {
         self.state.get_unchecked(self.world.entities(), entity)
     }
 
@@ -254,7 +254,7 @@ impl<'a, Q: Query> Fetcher<'a, Q> {
     /// If the entity doesn't exist or doesn't match the query, then a
     /// [`GetError`] is returned.
     #[inline]
-    pub fn get_mut(&mut self, entity: EntityId) -> Result<Q::Item<'_>, GetError> {
+    pub fn get_mut(&mut self, entity: EntityId) -> Result<Q::This<'_>, GetError> {
         unsafe { self.state.get_unchecked(self.world.entities(), entity) }
     }
 
@@ -275,7 +275,7 @@ impl<'a, Q: Query> Fetcher<'a, Q> {
     pub fn get_many_mut<const N: usize>(
         &mut self,
         entities: [EntityId; N],
-    ) -> Result<[Q::Item<'_>; N], GetManyMutError> {
+    ) -> Result<[Q::This<'_>; N], GetManyMutError> {
         unsafe { self.state.get_many_mut(self.world.entities(), entities) }
     }
 
@@ -294,7 +294,7 @@ impl<'a, Q: Query> Fetcher<'a, Q> {
 }
 
 impl<'a, Q: Query> IntoIterator for Fetcher<'a, Q> {
-    type Item = Q::Item<'a>;
+    type Item = Q::This<'a>;
 
     type IntoIter = Iter<'a, Q>;
 
@@ -304,7 +304,7 @@ impl<'a, Q: Query> IntoIterator for Fetcher<'a, Q> {
 }
 
 impl<'a, Q: ReadOnlyQuery> IntoIterator for &'a Fetcher<'_, Q> {
-    type Item = Q::Item<'a>;
+    type Item = Q::This<'a>;
 
     type IntoIter = Iter<'a, Q>;
 
@@ -314,7 +314,7 @@ impl<'a, Q: ReadOnlyQuery> IntoIterator for &'a Fetcher<'_, Q> {
 }
 
 impl<'a, Q: Query> IntoIterator for &'a mut Fetcher<'_, Q> {
-    type Item = Q::Item<'a>;
+    type Item = Q::This<'a>;
 
     type IntoIter = Iter<'a, Q>;
 
@@ -450,12 +450,12 @@ where
 /// world.send(E);
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Debug)]
-pub struct Single<'a, Q: Query>(pub Q::Item<'a>);
+pub struct Single<Q>(pub Q);
 
-unsafe impl<Q: Query + 'static> HandlerParam for Single<'_, Q> {
+unsafe impl<Q: Query + 'static> HandlerParam for Single<Q> {
     type State = FetcherState<Q>;
 
-    type This<'a> = Single<'a, Q>;
+    type This<'a> = Single<Q::This<'a>>;
 
     fn init(world: &mut World, config: &mut HandlerConfig) -> Result<Self::State, InitError> {
         FetcherState::init(world, config)
@@ -470,8 +470,8 @@ unsafe impl<Q: Query + 'static> HandlerParam for Single<'_, Q> {
         world: UnsafeWorldCell<'a>,
     ) -> Self::This<'a> {
         match TrySingle::get(state, info, event_ptr, target_location, world) {
-            TrySingle(Ok(item)) => Single(item),
-            TrySingle(Err(e)) => {
+            Ok(item) => Single(item),
+            Err(e) => {
                 panic!(
                     "failed to fetch exactly one entity matching the query `{}`: {e}",
                     any::type_name::<Q>()
@@ -489,31 +489,47 @@ unsafe impl<Q: Query + 'static> HandlerParam for Single<'_, Q> {
     }
 }
 
-impl<'a, Q: Query> Deref for Single<'a, Q> {
-    type Target = Q::Item<'a>;
+impl<'a, T> Deref for Single<&'a T>
+where
+    &'a T: for<'b> Query<This<'b> = &'b T>,
+{
+    type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 
-impl<'a, Q: Query> DerefMut for Single<'a, Q> {
+impl<'a, T> Deref for Single<&'a mut T>
+where
+    &'a mut T: for<'b> Query<This<'b> = &'b mut T>,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+impl<'a, T> DerefMut for Single<&'a mut T>
+where
+    &'a mut T: for<'b> Query<This<'b> = &'b mut T>,
+{
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        self.0
     }
 }
 
-/// Like [`Single`], but contains a `Result` instead of panicking on error.
+/// Like [`Single`], but yields a `Result` rather than panicking on error.
 ///
 /// This is useful if you need to explicitly handle the situation where the
 /// query does not match exactly one entity.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub struct TrySingle<'a, Q: Query>(pub Result<Q::Item<'a>, SingleError>);
+pub type TrySingle<Q> = Result<Q, SingleError>;
 
-unsafe impl<Q: Query + 'static> HandlerParam for TrySingle<'_, Q> {
+unsafe impl<Q: Query + 'static> HandlerParam for TrySingle<Q> {
     type State = FetcherState<Q>;
 
-    type This<'a> = TrySingle<'a, Q>;
+    type This<'a> = Result<Q::This<'a>, SingleError>;
 
     fn init(world: &mut World, config: &mut HandlerConfig) -> Result<Self::State, InitError> {
         FetcherState::init(world, config)
@@ -529,14 +545,14 @@ unsafe impl<Q: Query + 'static> HandlerParam for TrySingle<'_, Q> {
         let mut it = state.iter_mut(world.archetypes());
 
         let Some(item) = it.next() else {
-            return TrySingle(Err(SingleError::QueryDoesNotMatch));
+            return Err(SingleError::QueryDoesNotMatch);
         };
 
         if it.next().is_some() {
-            return TrySingle(Err(SingleError::MoreThanOneMatch));
+            return Err(SingleError::MoreThanOneMatch);
         }
 
-        TrySingle(Ok(item))
+        Ok(item)
     }
 
     fn refresh_archetype(state: &mut Self::State, arch: &Archetype) {
@@ -548,22 +564,8 @@ unsafe impl<Q: Query + 'static> HandlerParam for TrySingle<'_, Q> {
     }
 }
 
-impl<'a, Q: Query> Deref for TrySingle<'a, Q> {
-    type Target = Result<Q::Item<'a>, SingleError>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<'a, Q: Query> DerefMut for TrySingle<'a, Q> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 /// Error raised when fetching exactly one entity matching a query fails.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum SingleError {
     /// Query does not match any entities
     QueryDoesNotMatch,
@@ -608,7 +610,7 @@ pub struct Iter<'a, Q: Query> {
 }
 
 impl<'a, Q: Query> Iterator for Iter<'a, Q> {
-    type Item = Q::Item<'a>;
+    type Item = Q::This<'a>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -697,28 +699,28 @@ impl<Q: Query> fmt::Debug for Iter<'_, Q> {
 unsafe impl<'a, Q> Send for Iter<'_, Q>
 where
     Q: Query,
-    Q::Item<'a>: Send,
+    Q::This<'a>: Send,
 {
 }
 
 unsafe impl<'a, Q> Sync for Iter<'a, Q>
 where
     Q: Query,
-    Q::Item<'a>: Sync,
+    Q::This<'a>: Sync,
 {
 }
 
 impl<'a, Q> UnwindSafe for Iter<'a, Q>
 where
     Q: Query,
-    Q::Item<'a>: UnwindSafe,
+    Q::This<'a>: UnwindSafe,
 {
 }
 
 impl<'a, Q> RefUnwindSafe for Iter<'a, Q>
 where
     Q: Query,
-    Q::Item<'a>: RefUnwindSafe,
+    Q::This<'a>: RefUnwindSafe,
 {
 }
 
@@ -1134,9 +1136,9 @@ mod tests {
 
         world.add_handler(
             |_: Receiver<E1>, s1: TrySingle<&C1>, s2: TrySingle<&C2>, s3: TrySingle<&C3>| {
-                assert_eq!(s1.0, Err(SingleError::QueryDoesNotMatch));
-                assert_eq!(s2.0, Ok(&C2(123)));
-                assert_eq!(s3.0, Err(SingleError::MoreThanOneMatch));
+                assert_eq!(s1, Err(SingleError::QueryDoesNotMatch));
+                assert_eq!(s2, Ok(&C2(123)));
+                assert_eq!(s3, Err(SingleError::MoreThanOneMatch));
             },
         );
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1017,7 +1017,7 @@ impl Default for MaybeInvalidAccess {
 /// data accessed by [`HandlerParam::get`].
 pub unsafe trait HandlerParam {
     /// Persistent data stored in the handler.
-    type State: 'static;
+    type State;
 
     /// The type produced by this handler param. This must be the type
     /// of `Self` but with the lifetime of `'a`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,9 @@ pub mod prelude {
         Despawn, EventMut, GlobalEvent, GlobalEventId, Insert, Receiver, ReceiverMut, Remove,
         Sender, Spawn, TargetedEvent, TargetedEventId,
     };
-    pub use crate::fetch::{Fetcher, GetError, Single, SingleError, TrySingle};
+    pub use crate::fetch::{
+        Fetcher, GetError, Single, SingleError, TrySingle,
+    };
     pub use crate::handler::{Handler, HandlerId, HandlerParam, IntoHandler};
     pub use crate::query::{Has, Not, Or, Query, ReadOnlyQuery, With, Xor};
     pub use crate::world::World;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,7 @@ pub mod prelude {
         Despawn, EventMut, GlobalEvent, GlobalEventId, Insert, Receiver, ReceiverMut, Remove,
         Sender, Spawn, TargetedEvent, TargetedEventId,
     };
-    pub use crate::fetch::{
-        Fetcher, GetError, Single, SingleError, TrySingle,
-    };
+    pub use crate::fetch::{Fetcher, GetError, Single, SingleError, TrySingle};
     pub use crate::handler::{Handler, HandlerId, HandlerParam, IntoHandler};
     pub use crate::query::{Has, Not, Or, Query, ReadOnlyQuery, With, Xor};
     pub use crate::world::World;


### PR DESCRIPTION
Fixes #59. However rather than introduce a separate `SingleMut` type (and `TrySingleMut`), I've made a few adjustments to the existing types.
- `Single` now has `Deref` and `DerefMut` impls specifically for references. `Single<&C>` now derefs to `&C` and not `&&C`.
- The lifetime on `Single` and `TrySingle` is unnecessary, so it has been removed.
  - Renamed `Query::Item` to `Query::This` and adjusted documentation. Before it was only a suggestion that `Query::Item` be the same type as `Self`, but now it is a hard requirement.
- `TrySingle<Q>` is now a type alias for `Result<Q, SingleError>`. Users no longer need to go through an additional layer of indirection when accessing the result.

Review? @andrewgazelka 