### PR TITLE
feat: make `Sender` state publicly accessible

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -666,6 +666,11 @@ impl<'a, ES: EventSet> Sender<'a, ES> {
         self.state
     }
 
+    /// Grab the world cell.
+    pub fn world(&self) -> &UnsafeWorldCell<'a> {
+        &self.world
+    }
+
     /// Add a [`TargetedEvent`] to the queue of events to send.
     ///
     /// The queue is flushed once all handlers for the current event have run.

--- a/src/event.rs
+++ b/src/event.rs
@@ -661,6 +661,10 @@ impl<'a, ES: EventSet> Sender<'a, ES> {
         unsafe { self.world.queue_global(ptr, GlobalEventIdx(event_idx)) };
     }
 
+    pub fn state(&self) -> &ES::Indices {
+        self.state
+    }
+
     /// Add a [`TargetedEvent`] to the queue of events to send.
     ///
     /// The queue is flushed once all handlers for the current event have run.

--- a/src/event.rs
+++ b/src/event.rs
@@ -661,6 +661,7 @@ impl<'a, ES: EventSet> Sender<'a, ES> {
         unsafe { self.world.queue_global(ptr, GlobalEventIdx(event_idx)) };
     }
 
+    /// Grab the state of the sender; the [`EventSet`] indices.
     pub fn state(&self) -> &ES::Indices {
         self.state
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -942,7 +942,7 @@ impl World {
 
     /// Send all queued events to handlers. The event queue will be empty after
     /// this call.
-    fn flush_event_queue(&mut self) {
+    pub fn flush_event_queue(&mut self) {
         'next_event: while let Some(item) = self.event_queue.pop() {
             struct EventDropper<'a> {
                 event: NonNull<u8>,


### PR DESCRIPTION
This is useful for having a way to prepare events in a multi-threaded context before actually sending them in a single-threaded context.

```rust
// todo: I'd love to see if we actually need the two lifetimes or not.
// We might be able to just use one for both of them, but I never really figure out when I need one versus two.
struct SenderLocal<'a, 'b, ES: EventSet> {
    state: &'b ES::Indices,
    bump: &'a Bump,
    pending_write: Vec<(NonNull<u8>, GlobalEventIdx)>,
}

impl<'a, 'b, ES: EventSet> SenderLocal<'a, 'b, ES> {
    pub fn new(state: &'b ES::Indices, bump: &'a Bump) -> Self {
        Self {
            state,
            bump,

            // todo: Potentially, this should be under bump allocator, but let's profile before trying to do that.
            pending_write: Vec::new(),
        }
    }

    // todo: what does track caller do?
    #[track_caller]
    pub fn send<E: GlobalEvent + 'static>(&mut self, event: E) {
        // The event type and event set are all compile time known, so the compiler
        // should be able to optimize this away.
        let event_idx = ES::find_index::<E>(self.state).unwrap_or_else(|| {
            panic!(
                "global event `{}` is not in the `EventSet` of this `Sender`",
                any::type_name::<E>()
            )
        });

        // let ptr = self.alloc_layout(Layout::new::<E>());
        let ptr = self.bump.alloc_layout(Layout::new::<E>());

        unsafe { ptr::write::<E>(ptr.as_ptr().cast(), event) };

        // This will be saved until the end of the system, where we will be sending the events in one thread synchronously.
        // unsafe { self.world.queue_global(ptr, GlobalEventIdx(event_idx)) };
        self.pending_write.push((ptr, GlobalEventIdx(event_idx)));
    }
}
```