### PR TITLE
Make `Single` more like a smart pointer

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -425,8 +425,8 @@ mod tests {
         let c1 = world.add_component::<A>();
         let e1 = world.spawn();
         world.insert(e1, A("hello".into()));
-        let s1 = world.add_handler(|_: Receiver<E>, Single(A(a)): Single<&mut A>| {
-            a.push_str("hello");
+        let s1 = world.add_handler(|_: Receiver<E>, mut a: Single<&mut A>| {
+            a.0.push_str("hello");
         });
         world.send(E);
 
@@ -443,8 +443,8 @@ mod tests {
         let e2 = world.spawn();
         assert!(world.entities().contains(e2));
         world.insert(e2, B(vec![]));
-        let s2 = world.add_handler(|_: Receiver<E>, Single(B(b)): Single<&mut B>| {
-            b.push("hello".into());
+        let s2 = world.add_handler(|_: Receiver<E>, mut b: Single<&mut B>| {
+            b.0.push("hello".into());
         });
         world.send(E);
         assert_eq!(world.get::<B>(e2), Some(&B(vec!["hello".into()])));

--- a/src/event.rs
+++ b/src/event.rs
@@ -1176,14 +1176,14 @@ mod tests {
             sender.send(B(3));
         }
 
-        fn get_b_send_c(r: Receiver<B>, sender: Sender<C>, res: Single<&mut Result>) {
-            res.0 .0.push(r.event.0);
+        fn get_b_send_c(r: Receiver<B>, sender: Sender<C>, mut res: Single<&mut Result>) {
+            res.0.push(r.event.0);
             sender.send(C(r.event.0 + 1));
             sender.send(C(r.event.0 + 2));
         }
 
-        fn get_c(r: Receiver<C>, res: Single<&mut Result>) {
-            res.0 .0.push(r.event.0);
+        fn get_c(r: Receiver<C>, mut res: Single<&mut Result>) {
+            res.0.push(r.event.0);
         }
 
         let mut world = World::new();

--- a/src/query.rs
+++ b/src/query.rs
@@ -884,9 +884,9 @@ mod tests {
                 let matching_entity = world.spawn();
                 world.insert(matching_entity, Matching(matching));
 
-                world.add_handler(move |_: Receiver<E>, f: Fetcher<(EntityId, $query)>, matching: Single<&mut Matching>| {
+                world.add_handler(move |_: Receiver<E>, f: Fetcher<(EntityId, $query)>, mut matching: Single<&mut Matching>| {
                     for (e, _) in f {
-                        if e != matching_entity && !matching.0.0.shift_remove(&e) {
+                        if e != matching_entity && !matching.0.shift_remove(&e) {
                             panic!("matched entity unexpectedly {e:?}");
                         }
                     }


### PR DESCRIPTION
Remove the public `.0` field from `Single` since it doesn't mix well with `Deref`.